### PR TITLE
feat(npm): restart stale tsmd on package upgrade

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,8 @@ The workflow:
 6. Publishes `@tashian/tsm@<version>` second
 7. Both npm publishes carry provenance attestations linking back to this exact workflow run
 
+The `@tashian/tsm` wrapper ships a `postinstall` script that SIGTERMs any running `tsmd` on darwin so upgrades pick up the new binary on the next `tsm` invocation. It is a no-op on other platforms.
+
 ## Local dry-run
 
 Before tagging, you can sanity-check the build and packaging on your laptop:

--- a/npm/wrapper/README.md
+++ b/npm/wrapper/README.md
@@ -17,6 +17,8 @@ pnpm add -g @tashian/tsm
 
 This package is a thin shim. The actual binaries are pulled in via `optionalDependencies` based on your platform — currently only `@tashian/tsm-darwin-arm64` (Apple Silicon Macs).
 
+On upgrade, the postinstall script SIGTERMs any running `tsmd` so the next `tsm` command picks up the new binary. The daemon is auto-respawned on demand, so you'll Touch ID re-unlock once after upgrading. If you install with `--ignore-scripts`, the old daemon keeps running until you `pkill tsmd` (or reboot) yourself.
+
 ## Usage
 
 ```sh

--- a/npm/wrapper/package.json
+++ b/npm/wrapper/package.json
@@ -22,9 +22,13 @@
   "bin": {
     "tsm": "tsm"
   },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
   "files": [
     "tsm",
     "shim.js",
+    "scripts/postinstall.js",
     "README.md",
     "LICENSE"
   ],

--- a/npm/wrapper/scripts/postinstall.js
+++ b/npm/wrapper/scripts/postinstall.js
@@ -1,0 +1,137 @@
+"use strict";
+
+// postinstall.js — stop any running tsmd so the next `tsm` command picks up
+// the freshly installed binary.
+//
+// Why SIGTERM instead of an RPC `tsm daemon stop`: the postinstall runs after
+// the new binaries land, but the running daemon is still the *old* one (and
+// may live in a different prefix entirely, e.g. Homebrew). SIGTERM is simple
+// and version-independent. The daemon's own SIGTERM handler closes the socket
+// and zeros the master key on process exit. The next `tsm` command will
+// EnsureRunning and respawn the new binary on demand.
+//
+// This script must never fail the install. All errors are swallowed or
+// downgraded to a warning on stderr.
+
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+// Resolve the absolute path of the tsmd binary that just landed via the
+// optional platform package. Returns null if the platform package isn't
+// installed (e.g. user passed --no-optional, or we're on an unsupported arch
+// — main() should not even call this on non-darwin).
+function resolveTsmdPath({ requireResolve = require.resolve } = {}) {
+    try {
+        const pkgJson = requireResolve("@tashian/tsm-darwin-arm64/package.json");
+        return path.join(path.dirname(pkgJson), "bin", "tsmd");
+    } catch {
+        return null;
+    }
+}
+
+// Run pgrep with a single arg list and return the parsed PIDs. pgrep exits 1
+// when there are no matches; we treat that (and ENOENT) as "no pids".
+function pgrepPids(args, exec) {
+    let out;
+    try {
+        out = exec("pgrep", args, { stdio: ["ignore", "pipe", "ignore"] });
+    } catch (err) {
+        // status 1 = no match, ENOENT = pgrep missing. Either way: no pids.
+        return [];
+    }
+    return String(out)
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => parseInt(s, 10))
+        .filter((n) => Number.isFinite(n) && n > 0);
+}
+
+// Find any running tsmd processes worth stopping. Two passes:
+//   1. Path-strict: pgrep -f <absolute path of new tsmd>. Catches the common
+//      case where the user is upgrading an npm-installed tsm.
+//   2. Permissive owned-pid: pgrep -u $USER -f 'tsmd( |$)'. Catches the
+//      cross-prefix case (Homebrew tsmd running, user upgrades to npm) and
+//      the case where the daemon was launched from ~/.local/bin etc. Scoped
+//      to the current user so we never touch a system-wide daemon owned by
+//      someone else.
+function findRunningTsmdPids(tsmdPath, { execFileSync: exec = execFileSync } = {}) {
+    const pids = new Set();
+    for (const p of pgrepPids(["-f", tsmdPath], exec)) {
+        pids.add(p);
+    }
+    const user = process.env.USER || "nobody";
+    for (const p of pgrepPids(["-u", user, "-f", "^.*tsmd( |$)"], exec)) {
+        pids.add(p);
+    }
+    return Array.from(pids);
+}
+
+// SIGTERM each pid. Tolerates EPERM (daemon owned by another user — possible
+// after a stray `sudo npm install`) with a warning. Swallows ESRCH (process
+// already gone, race between pgrep and kill).
+function stopPids(pids, { kill = process.kill.bind(process), warn = console.warn } = {}) {
+    for (const pid of pids) {
+        try {
+            kill(pid, "SIGTERM");
+        } catch (err) {
+            if (err && err.code === "ESRCH") {
+                continue;
+            }
+            if (err && err.code === "EPERM") {
+                warn(
+                    `tsm: could not stop pid ${pid} (EPERM). ` +
+                        `Run 'sudo pkill tsmd' once, then 'tsm status' to respawn.`,
+                );
+                continue;
+            }
+            warn(`tsm: could not stop pid ${pid}: ${err && err.message ? err.message : err}`);
+        }
+    }
+}
+
+// Glue. Always returns 0 — postinstall must not fail npm install.
+function main(deps = {}) {
+    const platform = deps.platform || process.platform;
+    if (platform !== "darwin") {
+        return 0;
+    }
+    const resolve = deps.resolveTsmdPath || resolveTsmdPath;
+    const find = deps.findRunningTsmdPids || findRunningTsmdPids;
+    const stop = deps.stopPids || stopPids;
+
+    let tsmdPath;
+    try {
+        tsmdPath = resolve();
+    } catch {
+        return 0;
+    }
+    if (!tsmdPath) {
+        return 0;
+    }
+
+    let pids;
+    try {
+        pids = find(tsmdPath);
+    } catch {
+        return 0;
+    }
+
+    try {
+        stop(pids);
+    } catch {
+        // last-ditch swallow
+    }
+    return 0;
+}
+
+module.exports = {
+    resolveTsmdPath,
+    findRunningTsmdPids,
+    stopPids,
+    main,
+};
+
+if (require.main === module) {
+    process.exit(main());
+}

--- a/npm/wrapper/scripts/postinstall.test.js
+++ b/npm/wrapper/scripts/postinstall.test.js
@@ -1,0 +1,250 @@
+"use strict";
+
+// Tests for postinstall.js. Uses Node's built-in test runner so we don't
+// need any dev dependencies in the wrapper package.
+//
+//   node --test scripts/postinstall.test.js
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+    resolveTsmdPath,
+    findRunningTsmdPids,
+    stopPids,
+    main,
+} = require("./postinstall.js");
+
+// --- resolveTsmdPath --------------------------------------------------------
+
+test("resolveTsmdPath returns <pkgDir>/bin/tsmd when platform pkg is installed", () => {
+    const fakePkgJson = "/fake/node_modules/@tashian/tsm-darwin-arm64/package.json";
+    const requireResolve = (id) => {
+        assert.equal(id, "@tashian/tsm-darwin-arm64/package.json");
+        return fakePkgJson;
+    };
+    const got = resolveTsmdPath({ requireResolve });
+    assert.equal(got, path.join(path.dirname(fakePkgJson), "bin", "tsmd"));
+});
+
+test("resolveTsmdPath returns null when platform pkg is missing", () => {
+    const requireResolve = () => {
+        const err = new Error("Cannot find module");
+        err.code = "MODULE_NOT_FOUND";
+        throw err;
+    };
+    const got = resolveTsmdPath({ requireResolve });
+    assert.equal(got, null);
+});
+
+// --- findRunningTsmdPids ----------------------------------------------------
+
+function fakeExecFor(responses) {
+    // responses is keyed by the joined args of pgrep, value is either
+    // { stdout: "..." } or { error: { code, status } }.
+    return (cmd, args) => {
+        const key = args.join(" ");
+        const r = responses[key];
+        if (!r) {
+            throw new Error(`unexpected exec: ${cmd} ${key}`);
+        }
+        if (r.error) {
+            const e = new Error(r.error.message || "exec failed");
+            if (r.error.code) e.code = r.error.code;
+            if (typeof r.error.status === "number") e.status = r.error.status;
+            throw e;
+        }
+        return Buffer.from(r.stdout || "");
+    };
+}
+
+test("findRunningTsmdPids returns [] when no processes match", () => {
+    const tsmdPath = "/u/.npm/.../bin/tsmd";
+    // pgrep exits 1 with no stdout when no match; execFileSync throws.
+    const exec = fakeExecFor({
+        [`-f ${tsmdPath}`]: { error: { status: 1, message: "no match" } },
+        [`-u ${process.env.USER || "nobody"} -f ^.*tsmd( |$)`]: {
+            error: { status: 1, message: "no match" },
+        },
+    });
+    const got = findRunningTsmdPids(tsmdPath, { execFileSync: exec });
+    assert.deepEqual(got, []);
+});
+
+test("findRunningTsmdPids returns single pid from path-strict pass", () => {
+    const tsmdPath = "/u/.npm/.../bin/tsmd";
+    const exec = fakeExecFor({
+        [`-f ${tsmdPath}`]: { stdout: "12345\n" },
+        [`-u ${process.env.USER || "nobody"} -f ^.*tsmd( |$)`]: {
+            error: { status: 1 },
+        },
+    });
+    const got = findRunningTsmdPids(tsmdPath, { execFileSync: exec });
+    assert.deepEqual(got, [12345]);
+});
+
+test("findRunningTsmdPids dedupes pids across both passes", () => {
+    const tsmdPath = "/u/.npm/.../bin/tsmd";
+    const exec = fakeExecFor({
+        [`-f ${tsmdPath}`]: { stdout: "12345\n" },
+        [`-u ${process.env.USER || "nobody"} -f ^.*tsmd( |$)`]: {
+            // permissive pass: returns the same pid plus another (Homebrew remnant)
+            stdout: "12345\n67890\n",
+        },
+    });
+    const got = findRunningTsmdPids(tsmdPath, { execFileSync: exec });
+    assert.deepEqual(got.sort(), [12345, 67890]);
+});
+
+test("findRunningTsmdPids returns multiple pids from a single pass", () => {
+    const tsmdPath = "/u/.npm/.../bin/tsmd";
+    const exec = fakeExecFor({
+        [`-f ${tsmdPath}`]: { stdout: "111\n222\n333\n" },
+        [`-u ${process.env.USER || "nobody"} -f ^.*tsmd( |$)`]: {
+            error: { status: 1 },
+        },
+    });
+    const got = findRunningTsmdPids(tsmdPath, { execFileSync: exec });
+    assert.deepEqual(got.sort((a, b) => a - b), [111, 222, 333]);
+});
+
+test("findRunningTsmdPids returns [] when pgrep binary is not found", () => {
+    const tsmdPath = "/u/.npm/.../bin/tsmd";
+    const exec = (cmd, args) => {
+        const e = new Error("spawn pgrep ENOENT");
+        e.code = "ENOENT";
+        throw e;
+    };
+    const got = findRunningTsmdPids(tsmdPath, { execFileSync: exec });
+    assert.deepEqual(got, []);
+});
+
+// --- stopPids ---------------------------------------------------------------
+
+test("stopPids is a no-op for empty list", () => {
+    let called = false;
+    const kill = () => {
+        called = true;
+    };
+    stopPids([], { kill });
+    assert.equal(called, false);
+});
+
+test("stopPids sends SIGTERM to each pid", () => {
+    const sent = [];
+    const kill = (pid, sig) => sent.push([pid, sig]);
+    stopPids([1, 2, 3], { kill });
+    assert.deepEqual(sent, [
+        [1, "SIGTERM"],
+        [2, "SIGTERM"],
+        [3, "SIGTERM"],
+    ]);
+});
+
+test("stopPids tolerates EPERM with a warning, does not throw", () => {
+    const warned = [];
+    const kill = (pid) => {
+        const e = new Error("operation not permitted");
+        e.code = "EPERM";
+        throw e;
+    };
+    const warn = (msg) => warned.push(msg);
+    stopPids([42], { kill, warn });
+    assert.equal(warned.length, 1);
+    assert.match(warned[0], /42/);
+    assert.match(warned[0], /EPERM/);
+});
+
+test("stopPids swallows ESRCH silently", () => {
+    const warned = [];
+    const kill = () => {
+        const e = new Error("no such process");
+        e.code = "ESRCH";
+        throw e;
+    };
+    const warn = (msg) => warned.push(msg);
+    stopPids([7], { kill, warn });
+    assert.deepEqual(warned, []);
+});
+
+test("stopPids re-warns on unexpected error codes but does not throw", () => {
+    const warned = [];
+    const kill = () => {
+        const e = new Error("kaboom");
+        e.code = "EWHATEVER";
+        throw e;
+    };
+    const warn = (msg) => warned.push(msg);
+    stopPids([99], { kill, warn });
+    assert.equal(warned.length, 1);
+    assert.match(warned[0], /99/);
+});
+
+// --- main -------------------------------------------------------------------
+
+test("main no-ops on non-darwin", () => {
+    const calls = { resolve: 0, find: 0, kill: 0 };
+    const code = main({
+        platform: "linux",
+        resolveTsmdPath: () => {
+            calls.resolve++;
+            return "/should/not/be/used";
+        },
+        findRunningTsmdPids: () => {
+            calls.find++;
+            return [1];
+        },
+        stopPids: () => {
+            calls.kill++;
+        },
+    });
+    assert.equal(code, 0);
+    assert.deepEqual(calls, { resolve: 0, find: 0, kill: 0 });
+});
+
+test("main no-ops when platform package is missing", () => {
+    let killed = false;
+    const code = main({
+        platform: "darwin",
+        resolveTsmdPath: () => null,
+        findRunningTsmdPids: () => {
+            throw new Error("should not be called");
+        },
+        stopPids: () => {
+            killed = true;
+        },
+    });
+    assert.equal(code, 0);
+    assert.equal(killed, false);
+});
+
+test("main resolves, finds, and kills on darwin", () => {
+    const seen = {};
+    const code = main({
+        platform: "darwin",
+        resolveTsmdPath: () => "/p/bin/tsmd",
+        findRunningTsmdPids: (p) => {
+            seen.path = p;
+            return [101];
+        },
+        stopPids: (pids) => {
+            seen.pids = pids;
+        },
+    });
+    assert.equal(code, 0);
+    assert.equal(seen.path, "/p/bin/tsmd");
+    assert.deepEqual(seen.pids, [101]);
+});
+
+test("main returns 0 even if find throws (postinstall must not fail)", () => {
+    const code = main({
+        platform: "darwin",
+        resolveTsmdPath: () => "/p/bin/tsmd",
+        findRunningTsmdPids: () => {
+            throw new Error("unexpected pgrep failure");
+        },
+        stopPids: () => {},
+    });
+    assert.equal(code, 0);
+});


### PR DESCRIPTION
## Summary
- Adds a `postinstall` script to the npm wrapper that SIGTERMs any running tsmd on darwin so the next `tsm` command picks up the new binary.
- Idempotent and side-effect-light: no respawn, no pidfile, no JSON-RPC dependency.
- Skips silently on non-darwin (e.g. Linux CI installing the wrapper).
- Handles cross-prefix upgrades (Homebrew → npm) via a permissive owned-pid pass.

Closes #5

## Implementation notes
- Script is refactored into pure-ish functions (`resolveTsmdPath`, `findRunningTsmdPids`, `stopPids`, `main`) with injectable deps (`requireResolve`, `execFileSync`, `process.kill`) so `node:test` covers every branch without spawning real processes.
- `if (require.main === module) main()` keeps `require()` side-effect-free for the test harness.
- `EPERM` on `kill` (daemon owned by another user after a stray `sudo`) downgrades to a warning, never fails the install. `ESRCH` swallowed silently (race between `pgrep` and `kill`). Unknown error codes are warned but still non-fatal.
- `package.json` `files` lists `scripts/postinstall.js` explicitly so the test file (`scripts/postinstall.test.js`) is not shipped in the published tarball.
- `npm/wrapper/README.md` notes the upgrade behavior and the `--ignore-scripts` opt-out.
- `RELEASING.md` gets a one-liner about the postinstall.

## Deferred
- **T6 (CI smoke test step) is deferred.** Per repo conventions for this PR I did not add a new GH Actions workflow file; extending `ci.yml` with a Node test step is a follow-up. The unit tests are runnable today via `node --test npm/wrapper/scripts/postinstall.test.js`.
- **T7 (real `npm install -g .` smoke test) is deferred to manual verification by the maintainer**, per the task constraints (do not mutate the user's global npm prefix from automation).

## Test plan
- [x] `node --test npm/wrapper/scripts/postinstall.test.js` passes (16/16)
- [x] `npm pack --dry-run` from `npm/wrapper/` includes `scripts/postinstall.js` and excludes the test file
- [ ] Manual on darwin: `tsm status` (spawn daemon) → `cd npm/wrapper && npm install -g .` → `pgrep -fl tsmd` empty → `tsm status` respawns