### PR TITLE
feat(tsm): allow agents to sweep naked creds via `tsm add`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -14,6 +14,21 @@ import (
 	"golang.org/x/term"
 )
 
+// addOptions captures inputs for runAddWith. Extracted so tests can inject a
+// stdin reader and skip the cobra flag plumbing / TTY detection.
+type addOptions struct {
+	Name        string
+	DisplayName string
+	Description string
+	Confirm     bool
+	Tags        []string
+	FromFile    string
+	NoInput     bool
+	Stdin       io.Reader
+	StdinTTY    bool
+	Stdout      io.Writer
+}
+
 func newAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -24,8 +39,27 @@ Interactive:  tsm add
 Piped:        echo "secret_value" | tsm add --name foo --no-input
 From file:    tsm add --name foo --from-file /path/to/key`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name, _ := cmd.Flags().GetString("name")
+			displayName, _ := cmd.Flags().GetString("display-name")
+			description, _ := cmd.Flags().GetString("description")
+			confirm, _ := cmd.Flags().GetBool("confirm")
+			tags, _ := cmd.Flags().GetStringSlice("tags")
+			fromFile, _ := cmd.Flags().GetString("from-file")
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			opts := addOptions{
+				Name:        name,
+				DisplayName: displayName,
+				Description: description,
+				Confirm:     confirm,
+				Tags:        tags,
+				FromFile:    fromFile,
+				NoInput:     noInput,
+				Stdin:       os.Stdin,
+				StdinTTY:    term.IsTerminal(int(os.Stdin.Fd())),
+				Stdout:      os.Stdout,
+			}
 			return withUnlockedClient(func(c client.Caller) error {
-				return runAdd(cmd, c)
+				return runAddWith(c, opts)
 			})
 		},
 	}
@@ -39,14 +73,14 @@ From file:    tsm add --name foo --from-file /path/to/key`,
 	return cmd
 }
 
-func runAdd(cmd *cobra.Command, c client.Caller) error {
-	name, _ := cmd.Flags().GetString("name")
-	displayName, _ := cmd.Flags().GetString("display-name")
-	description, _ := cmd.Flags().GetString("description")
-	confirm, _ := cmd.Flags().GetBool("confirm")
-	tags, _ := cmd.Flags().GetStringSlice("tags")
-	fromFile, _ := cmd.Flags().GetString("from-file")
-	noInput, _ := cmd.Flags().GetBool("no-input")
+func runAddWith(c client.Caller, opts addOptions) error {
+	name := opts.Name
+	displayName := opts.DisplayName
+	description := opts.Description
+	confirm := opts.Confirm
+	tags := opts.Tags
+	fromFile := opts.FromFile
+	noInput := opts.NoInput
 
 	var value string
 
@@ -56,14 +90,12 @@ func runAdd(cmd *cobra.Command, c client.Caller) error {
 			return fmt.Errorf("read file: %w", err)
 		}
 		value = strings.TrimRight(string(data), "\n")
-	} else if noInput || !term.IsTerminal(int(os.Stdin.Fd())) {
-		scanner := bufio.NewScanner(os.Stdin)
-		if scanner.Scan() {
-			value = scanner.Text()
-		}
-		if err := scanner.Err(); err != nil {
+	} else if noInput || !opts.StdinTTY {
+		data, err := io.ReadAll(opts.Stdin)
+		if err != nil {
 			return fmt.Errorf("read stdin: %w", err)
 		}
+		value = strings.TrimRight(string(data), "\n")
 	} else {
 		form := huh.NewForm(
 			huh.NewGroup(
@@ -144,13 +176,17 @@ func runAdd(cmd *cobra.Command, c client.Caller) error {
 		return handleError(err)
 	}
 
+	out := opts.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
 	if jsonOutput() {
-		return printJSON(map[string]bool{"ok": true})
+		return printJSONTo(out, map[string]bool{"ok": true})
 	}
 	if displayName != "" && displayName != name {
-		fmt.Printf("Secret '%s' added (id: %s).\n", displayName, name)
+		fmt.Fprintf(out, "Secret '%s' added (id: %s).\n", displayName, name)
 	} else {
-		fmt.Printf("Secret '%s' added.\n", name)
+		fmt.Fprintf(out, "Secret '%s' added.\n", name)
 	}
 	return nil
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// addMock returns a mockCaller that ACKs vault.unlock and captures the
+// vault.add params for assertions. The captured params are stored in *into.
+func addMock(into *map[string]any) *mockCaller {
+	return &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			switch method {
+			case "vault.unlock":
+				return nil, nil
+			case "vault.add":
+				if into != nil {
+					*into = params
+				}
+				return nil, nil
+			}
+			return nil, errors.New("unexpected method " + method)
+		},
+	}
+}
+
+func TestAdd_StdinPipe(t *testing.T) {
+	var captured map[string]any
+	mock := addMock(&captured)
+	var stdout bytes.Buffer
+	err := runAddWith(mock, addOptions{
+		Name:        "openai-key-foo",
+		DisplayName: "OpenAI API Key (foo)",
+		Description: "Swept from .env",
+		Stdin:       strings.NewReader("sk-proj-abc123\n"),
+		StdinTTY:    false,
+		Stdout:      &stdout,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["name"] != "openai-key-foo" {
+		t.Errorf("name: got %v, want openai-key-foo", captured["name"])
+	}
+	if captured["value"] != "sk-proj-abc123" {
+		t.Errorf("value: got %q, want %q (trailing newline must be trimmed)", captured["value"], "sk-proj-abc123")
+	}
+	if captured["display_name"] != "OpenAI API Key (foo)" {
+		t.Errorf("display_name: got %v", captured["display_name"])
+	}
+	if captured["description"] != "Swept from .env" {
+		t.Errorf("description: got %v", captured["description"])
+	}
+}
+
+func TestAdd_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.txt")
+	// Trailing newline should be stripped (matching how editors save text files).
+	if err := os.WriteFile(path, []byte("ghp_secret_value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var captured map[string]any
+	mock := addMock(&captured)
+	err := runAddWith(mock, addOptions{
+		Name:     "gh-pat",
+		FromFile: path,
+		StdinTTY: true, // shouldn't matter; --from-file wins
+		Stdout:   &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["value"] != "ghp_secret_value" {
+		t.Errorf("value: got %q, want %q", captured["value"], "ghp_secret_value")
+	}
+}
+
+func TestAdd_LargeStdinValue(t *testing.T) {
+	// 256KB value — exceeds bufio.Scanner's default 64KB buffer.
+	// This test guards against regression to bufio.Scanner.
+	const size = 256 * 1024
+	big := strings.Repeat("a", size)
+	var captured map[string]any
+	mock := addMock(&captured)
+	err := runAddWith(mock, addOptions{
+		Name:     "big",
+		Stdin:    strings.NewReader(big),
+		StdinTTY: false,
+		Stdout:   &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := captured["value"].(string)
+	if !ok {
+		t.Fatalf("value not a string: %T", captured["value"])
+	}
+	if len(got) != size {
+		t.Errorf("value length: got %d, want %d (truncation suggests bufio.Scanner regression)", len(got), size)
+	}
+	if got != big {
+		t.Errorf("value content mismatch (length ok but bytes differ)")
+	}
+}
+
+func TestAdd_MultiLineStdinValue(t *testing.T) {
+	// Multi-line values (PEM bundles, GCP service-account JSON) must be
+	// preserved end-to-end with internal newlines intact. Only the trailing
+	// newline is stripped.
+	pem := "-----BEGIN PRIVATE KEY-----\nMIIEv...\nQ==\n-----END PRIVATE KEY-----\n"
+	var captured map[string]any
+	mock := addMock(&captured)
+	err := runAddWith(mock, addOptions{
+		Name:     "tls-key",
+		Stdin:    strings.NewReader(pem),
+		StdinTTY: false,
+		Stdout:   &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.TrimRight(pem, "\n")
+	if captured["value"] != want {
+		t.Errorf("multi-line value not preserved.\n got: %q\nwant: %q", captured["value"], want)
+	}
+}
+
+func TestAdd_RejectsValueFlag(t *testing.T) {
+	// Regression guard: per CLAUDE.md, --value must NEVER be added to tsm add.
+	// Flag values appear in `ps` output and shell history, leaking the secret.
+	cmd := newAddCmd()
+	if f := cmd.Flags().Lookup("value"); f != nil {
+		t.Fatalf("tsm add must not have a --value flag (would leak secrets via ps/shell history)")
+	}
+	if f := cmd.Flags().Lookup("secret"); f != nil {
+		t.Fatalf("tsm add must not have a --secret flag (would leak secrets via ps/shell history)")
+	}
+}
+
+func TestAdd_MissingNameNonInteractive(t *testing.T) {
+	mock := addMock(nil)
+	err := runAddWith(mock, addOptions{
+		// no Name, no DisplayName
+		Stdin:    strings.NewReader("some-value"),
+		StdinTTY: false,
+		Stdout:   &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected error when --name is missing in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention name, got: %v", err)
+	}
+}
+
+func TestAdd_MissingValueNonInteractive(t *testing.T) {
+	mock := addMock(nil)
+	err := runAddWith(mock, addOptions{
+		Name:     "foo",
+		Stdin:    strings.NewReader(""), // empty stdin
+		StdinTTY: false,
+		Stdout:   &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected error when value is empty")
+	}
+	if !strings.Contains(err.Error(), "value") {
+		t.Errorf("error should mention value, got: %v", err)
+	}
+}
+
+func TestAdd_JSONOutput(t *testing.T) {
+	prev := jsonFlag
+	jsonFlag = true
+	t.Cleanup(func() { jsonFlag = prev })
+
+	mock := addMock(nil)
+	var stdout bytes.Buffer
+	err := runAddWith(mock, addOptions{
+		Name:        "foo",
+		DisplayName: "Foo Display",
+		Stdin:       strings.NewReader("v"),
+		StdinTTY:    false,
+		Stdout:      &stdout,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := stdout.String()
+	// Must be machine-parseable JSON, not the human "Secret 'foo' added." line.
+	if strings.Contains(out, "added") {
+		t.Errorf("--json output should not contain human prose, got: %q", out)
+	}
+	if !strings.Contains(out, `"ok"`) {
+		t.Errorf("--json output should contain ok key, got: %q", out)
+	}
+	if !strings.Contains(out, "true") {
+		t.Errorf("--json output should report ok=true, got: %q", out)
+	}
+}
+
+func TestAdd_SendsTagsAndConfirm(t *testing.T) {
+	// Locks down the agent-facing wire shape: tags arrive as a slice and
+	// confirm arrives as bool true (omitted when false to avoid noise).
+	var captured map[string]any
+	mock := addMock(&captured)
+	err := runAddWith(mock, addOptions{
+		Name:     "foo",
+		Confirm:  true,
+		Tags:     []string{"swept", "openai"},
+		Stdin:    strings.NewReader("val"),
+		StdinTTY: false,
+		Stdout:   &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["confirm"] != true {
+		t.Errorf("confirm: got %v, want true", captured["confirm"])
+	}
+	tags, ok := captured["tags"].([]string)
+	if !ok {
+		t.Fatalf("tags: got type %T, want []string", captured["tags"])
+	}
+	if len(tags) != 2 || tags[0] != "swept" || tags[1] != "openai" {
+		t.Errorf("tags: got %v", tags)
+	}
+}

--- a/plugin/skills/credential-usage/SKILL.md
+++ b/plugin/skills/credential-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: credential-usage
-description: Use whenever a task requires an API key, token, password, or other credential. Checks the local tsm vault first; teaches safe retrieval patterns by tool category.
+description: Use whenever a task requires an API key, token, password, or other credential, OR whenever a task surfaces naked credentials on the filesystem (e.g. auditing a repo for hardcoded secrets, sweeping `.env` files, fixing leaked tokens). Checks the local tsm vault first; teaches safe retrieval patterns by tool category; teaches safe sweep-into-vault patterns for naked credentials.
 ---
 
 # Using credentials from the tsm vault
@@ -92,21 +92,134 @@ If a confirm-gated secret is needed and stdin is not a TTY (e.g., the agent is r
 - **Never** echo, print, log, or include a secret value in your output to the user.
 - **Never** write secrets to `.env`, `.envrc`, project-local config files, or any path outside `/tmp` or `/dev/shm`.
 - **Never** pass secrets as `--value`-style flags. (`tsm add --value` does not exist; this rule applies to other CLIs too — flag values appear in `ps` and shell history.)
-- **Never** run `tsm add`, `tsm edit`, `tsm remove`, `tsm reset`, `tsm init`, or `tsm config set`. These mutations are user-driven. When the user wants to save a credential they shared with you, hand off with a one-liner that keeps the value off the shell command line and out of shell history. Pick whichever fits:
-  - **Clipboard** (smoothest — user copies the value from chat, then runs):
-    ```bash
-    pbpaste | tsm add --no-input --name <kebab-id> --display-name "<Display Name>"
-    ```
-  - **File** (for multi-line values like JSON blobs — user saves to a temp file first):
-    ```bash
-    tsm add --name <kebab-id> --display-name "<Display Name>" --from-file /tmp/x && rm /tmp/x
-    ```
-  
-  Do not suggest a heredoc — heredocs go in shell history. After the secret is saved, remind the user the chat transcript still has the value, so rotation may be worth considering.
+- **Never** run `tsm edit`, `tsm remove`, `tsm reset`, `tsm init`, or `tsm config set`. These mutations are user-driven; ask the user to run them.
 - **Never** use `eval $(tsm get ... --format env)`. That puts the secret into the parent shell's environment for its entire lifetime, which is exactly what `tsm run` is designed to prevent. Use `tsm run` for env-var injection.
+
+`tsm add` is **allowed** when sweeping naked credentials you've already discovered on disk — see §5 for the required workflow and safety guardrails. `tsm add` is the only mutation a `tsm` agent may run on its own initiative; everything else stays user-driven.
+
+## 5. Sweeping naked credentials into the vault
+
+When you discover a cleartext credential on the filesystem (in a `.env`, hardcoded in source, in an MCP config, in a shell history snippet) you may move it into the vault using `tsm add`. The value travels from the file into tsm and never appears in chat, in shell history, or in `ps` output.
+
+### Workflow
+
+1. **Check for an existing entry.** Run `tsm list --json` and look for a name, description, or tag that matches. If a matching entry exists and you can safely confirm the value matches, just rewrite the call site to use `tsm get`/`tsm run` (skip to step 5). If a matching entry exists but the value differs, surface to the user — do not silently overwrite.
+2. **Choose an id and display name.** The id is kebab-case, validated `^[a-zA-Z0-9_-]{1,128}$`. Pick something specific (`openai-key-myapp`, not just `openai-key`) so future sweeps don't collide.
+3. **Announce intent.** Tell the user, before running anything: which env var/file you're moving, the chosen id, and that the value will not appear in chat or shell history. Mention the Touch ID prompt.
+4. **Move the value via stdin or `--from-file`.** Use one of the safe forms below.
+5. **Verify, then scrub.** Confirm the entry exists with `tsm list --json` (which never includes values). Then remove/rewrite the original cleartext.
+6. **Replace the call site.** Update the consumer to use `tsm get` or `tsm run` per §2.
+7. **Warn about git history if applicable.** If the original file is committed to git, tell the user the value is in history and rotation is required. Do NOT run `git filter-repo`, `git filter-branch`, or BFG autonomously.
+
+### Safe transport: stdin pipe (preferred)
+
+`printf` is a shell builtin in bash/zsh, so the value does NOT appear in `ps` output. The Bash tool in Claude Code is `bash -c`, where `printf` is a builtin.
+
+```bash
+KEY=$(grep '^OPENAI_API_KEY=' .env | cut -d= -f2-)
+printf '%s' "$KEY" | tsm add \
+  --name openai-key-myapp \
+  --display-name "OpenAI API Key (myapp)" \
+  --description "Swept from ./.env on 2026-05-01" \
+  --tags swept,openai \
+  --json
+unset KEY
+# {"ok":true}
+```
+
+`tsm add` auto-detects piped (non-TTY) stdin, so `--no-input` is not required.
+
+### Safe transport: --from-file
+
+If the value is already in a file you control:
+
+```bash
+tsm add --name gcp-sa --display-name "GCP service account (myapp)" \
+  --from-file ./service-account.json --json
+# {"ok":true}
+rm ./service-account.json
+```
+
+`tsm add --from-file` reads the file and trims a single trailing newline. Multi-line values (PEM bundles, JSON blobs) are preserved verbatim.
+
+### Never (sweep-specific)
+
+- **Never** pass the value as a flag. `tsm add --value sk-…` does not exist and never will. Other agents/tools that show flag values in `ps` will leak the secret.
+- **Never** put the value in a positional argument. `tsm add foo sk-…` is rejected.
+- **Never** use `echo` to pipe the value. `echo` is not guaranteed to be a shell builtin (notably in fish without `builtin echo`). Use `printf '%s'` in bash/zsh.
+- **Never** use a heredoc (`<<EOF\nsk-…\nEOF`). Heredocs land in shell history.
+- **Never** paste the value into the chat transcript at any step. The transcript is durable; the value should travel from the file to tsm without being echoed.
+- **Never** write the value to an intermediate scratch file unless you `--from-file` it directly and `rm` immediately after. Don't `cat`, `head`, `tail`, or otherwise dump it to a buffer you can't clean up.
+- **Never** delete the source file before `tsm list --json` confirms the new entry exists. A daemon error during `tsm add` would otherwise lose the secret.
+- **Never** commit the scrubbed source file without warning the user the original value is in git history and rotation is required. Do NOT run `git filter-repo`, `git filter-branch`, or BFG autonomously.
+- **Never** run a sweep silently. Always announce intent and the chosen id before invoking `tsm add`, so the user can interject.
+
+### Worked example
+
+**Initial state:** `./.env`
+```
+DATABASE_URL=postgres://localhost/myapp
+OPENAI_API_KEY=sk-proj-abc123def456ghi789
+PORT=3000
+```
+
+**Agent's transcript to user:**
+
+> I noticed `OPENAI_API_KEY` is hardcoded in `./.env`. I'm going to move it into the tsm vault as `openai-key-myapp` and rewrite the call site to use `tsm run`. The value will not appear in chat or shell history. Please approve the Touch ID prompt when it appears.
+
+```bash
+# 1. Confirm no existing entry
+tsm list --json | jq '.[] | select(.name=="openai-key-myapp")'
+# (empty)
+
+# 2. Read the value into a shell variable, then pipe it through printf (builtin)
+KEY=$(grep '^OPENAI_API_KEY=' .env | cut -d= -f2-)
+printf '%s' "$KEY" | tsm add \
+  --name openai-key-myapp \
+  --display-name "OpenAI API Key (myapp)" \
+  --description "Swept from ./.env on 2026-05-01" \
+  --tags swept,openai \
+  --json
+unset KEY
+# {"ok":true}
+
+# 3. Verify (without revealing the value)
+tsm list --json | jq '.[] | select(.name=="openai-key-myapp") | {name,display_name,tags}'
+# {"name":"openai-key-myapp","display_name":"OpenAI API Key (myapp)","tags":["swept","openai"]}
+
+# 4. Remove the line from .env
+sed -i.bak '/^OPENAI_API_KEY=/d' .env && rm .env.bak
+
+# 5. Update the run script (or process manager) to inject via tsm run.
+#    e.g. in package.json:  "start": "tsm run --env OPENAI_API_KEY=openai-key-myapp -- node server.js"
+#    Or for a one-off:      tsm run --env OPENAI_API_KEY=openai-key-myapp -- node server.js
+```
+
+**Final state:** `./.env`
+```
+DATABASE_URL=postgres://localhost/myapp
+PORT=3000
+```
+
+**Final state:** `./package.json` (excerpt)
+```json
+"scripts": {
+  "start": "tsm run --env OPENAI_API_KEY=openai-key-myapp -- node server.js"
+}
+```
+
+**Agent's closing message to user:**
+
+> Moved `OPENAI_API_KEY` to tsm as `openai-key-myapp`. The original value was in `./.env`, which is gitignored — but please double-check `git log -S 'sk-proj-abc' -- .env` to confirm it never landed in history. If it did, rotate the key at platform.openai.com. The chat transcript above only contains the prefix `sk-proj-abc…` of the original value (which I included to identify it), so consider rotation regardless.
+
+Tagging swept credentials with `swept` makes future audits easy:
+
+```bash
+tsm list --json | jq '.[] | select(.tags | index("swept"))'
+```
 
 ## When tsm doesn't apply
 
-- The user pastes a credential inline in chat — use it for the current task, then offer to save it via the `pbpaste`/`--from-file` handoff in §4 (do not suggest bare `tsm add`, which makes them retype the value into the TUI).
+- The user pastes a credential inline in chat — use it for the current task, then offer to sweep it via the §5 workflow (`printf '%s' "$VAR" | tsm add …`) so the value moves into the vault without being retyped into the TUI.
 - The tool uses local OAuth that owns its own token lifecycle (gcloud user-OAuth, GitHub CLI's `gh auth login` flow). Use the tool's native auth; tsm doesn't help here.
-- The vault is empty or no relevant secret exists — tell the user, suggest a name and `tsm add`, and stop there.
+- The vault is empty or no relevant secret exists, and you have no value to sweep — tell the user, suggest a name, and stop there.


### PR DESCRIPTION
## Summary
- Inverts the credential-usage skill's blanket ban on `tsm add`: agents may now move discovered cleartext credentials into the vault following a documented safe workflow.
- Keeps the bans on `edit`, `remove`, `reset`, `init`, and `config set` (still user-driven).
- Replaces `bufio.Scanner` in `runAdd` with `io.ReadAll` + `TrimRight` so stdin values >64KB and multi-line values work.
- Adds `cmd/add_test.go` (was missing) to lock the agent-facing contract: stdin pipe, --from-file, large value, multi-line value, --json output, no `--value` flag, missing-name error.

Closes #6

## Test plan
- [ ] `go test ./cmd/...` passes
- [ ] `tsm add` still rejects a `--value` flag (regression test confirms)
- [ ] Skill section reads cleanly end-to-end with the worked example