### PR TITLE
feat: project-scoped secrets (MVP)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"tsm/internal/client"
@@ -14,6 +16,31 @@ import (
 	"golang.org/x/term"
 )
 
+// addOptions captures the flag inputs for runAddWith. Extracted for tests:
+// production wires these from cobra; tests inject directly so we can also
+// stub out the cwd resolver.
+type addOptions struct {
+	Name        string
+	DisplayName string
+	Description string
+	Confirm     bool
+	Tags        []string
+	FromFile    string
+	NoInput     bool
+	Here        bool
+	Projects    []string
+	// Getwd is the cwd resolver used by --here. In production this is
+	// os.Getwd; tests inject a deterministic stub.
+	Getwd func() (string, error)
+	// EvalSymlinks is filepath.EvalSymlinks in production.
+	EvalSymlinks func(string) (string, error)
+	// Stdin is the reader used in --no-input / piped mode.
+	Stdin    io.Reader
+	StdinTTY bool
+	// Stdout is where status output (e.g., "Secret 'x' added.") goes.
+	Stdout io.Writer
+}
+
 func newAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -22,10 +49,38 @@ func newAddCmd() *cobra.Command {
 
 Interactive:  tsm add
 Piped:        echo "secret_value" | tsm add --name foo --no-input
-From file:    tsm add --name foo --from-file /path/to/key`,
+From file:    tsm add --name foo --from-file /path/to/key
+Project:      tsm add --here --name foo --no-input
+Project:      tsm add --project /abs/path --name foo --no-input`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name, _ := cmd.Flags().GetString("name")
+			displayName, _ := cmd.Flags().GetString("display-name")
+			description, _ := cmd.Flags().GetString("description")
+			confirm, _ := cmd.Flags().GetBool("confirm")
+			tags, _ := cmd.Flags().GetStringSlice("tags")
+			fromFile, _ := cmd.Flags().GetString("from-file")
+			noInput, _ := cmd.Flags().GetBool("no-input")
+			here, _ := cmd.Flags().GetBool("here")
+			projects, _ := cmd.Flags().GetStringArray("project")
+
+			opts := addOptions{
+				Name:         name,
+				DisplayName:  displayName,
+				Description:  description,
+				Confirm:      confirm,
+				Tags:         tags,
+				FromFile:     fromFile,
+				NoInput:      noInput,
+				Here:         here,
+				Projects:     projects,
+				Getwd:        os.Getwd,
+				EvalSymlinks: filepath.EvalSymlinks,
+				Stdin:        os.Stdin,
+				StdinTTY:     term.IsTerminal(int(os.Stdin.Fd())),
+				Stdout:       os.Stdout,
+			}
 			return withUnlockedClient(func(c client.Caller) error {
-				return runAdd(cmd, c)
+				return runAddWith(c, opts)
 			})
 		},
 	}
@@ -36,17 +91,31 @@ From file:    tsm add --name foo --from-file /path/to/key`,
 	cmd.Flags().StringSlice("tags", nil, "tags (comma-separated)")
 	cmd.Flags().String("from-file", "", "read secret value from file")
 	cmd.Flags().Bool("no-input", false, "non-interactive mode (read value from stdin)")
+	cmd.Flags().Bool("here", false, "bind the secret to the current directory (project scope)")
+	cmd.Flags().StringArray("project", nil, "absolute path to bind the secret to (repeatable; project scope)")
 	return cmd
 }
 
-func runAdd(cmd *cobra.Command, c client.Caller) error {
-	name, _ := cmd.Flags().GetString("name")
-	displayName, _ := cmd.Flags().GetString("display-name")
-	description, _ := cmd.Flags().GetString("description")
-	confirm, _ := cmd.Flags().GetBool("confirm")
-	tags, _ := cmd.Flags().GetStringSlice("tags")
-	fromFile, _ := cmd.Flags().GetString("from-file")
-	noInput, _ := cmd.Flags().GetBool("no-input")
+func runAddWith(c client.Caller, opts addOptions) error {
+	name := opts.Name
+	displayName := opts.DisplayName
+	description := opts.Description
+	confirm := opts.Confirm
+	tags := opts.Tags
+	fromFile := opts.FromFile
+	noInput := opts.NoInput
+
+	// Resolve project roots from --here / --project flags. We do this before
+	// any prompting so an invalid path fails fast (and doesn't waste a Touch
+	// ID / huh form in the process).
+	roots, err := resolveProjectRoots(opts)
+	if err != nil {
+		return err
+	}
+	scope := "global"
+	if len(roots) > 0 {
+		scope = "project"
+	}
 
 	var value string
 
@@ -56,8 +125,8 @@ func runAdd(cmd *cobra.Command, c client.Caller) error {
 			return fmt.Errorf("read file: %w", err)
 		}
 		value = strings.TrimRight(string(data), "\n")
-	} else if noInput || !term.IsTerminal(int(os.Stdin.Fd())) {
-		scanner := bufio.NewScanner(os.Stdin)
+	} else if noInput || !opts.StdinTTY {
+		scanner := bufio.NewScanner(opts.Stdin)
 		if scanner.Scan() {
 			value = scanner.Text()
 		}
@@ -139,18 +208,79 @@ func runAdd(cmd *cobra.Command, c client.Caller) error {
 	if len(tags) > 0 {
 		params["tags"] = tags
 	}
+	if scope == "project" {
+		params["scope"] = "project"
+		params["roots"] = roots
+	}
 
 	if err := c.Call("vault.add", params, nil); err != nil {
 		return handleError(err)
 	}
 
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
 	if jsonOutput() {
-		return printJSON(map[string]bool{"ok": true})
+		return printJSONTo(stdout, map[string]bool{"ok": true})
 	}
 	if displayName != "" && displayName != name {
-		fmt.Printf("Secret '%s' added (id: %s).\n", displayName, name)
+		fmt.Fprintf(stdout, "Secret '%s' added (id: %s).\n", displayName, name)
 	} else {
-		fmt.Printf("Secret '%s' added.\n", name)
+		fmt.Fprintf(stdout, "Secret '%s' added.\n", name)
+	}
+	if scope == "project" {
+		fmt.Fprintf(stdout, "  scope: project (%s)\n", strings.Join(roots, ", "))
 	}
 	return nil
+}
+
+// resolveProjectRoots returns normalized absolute roots from --here and
+// --project flags, or nil for global scope. Symlinks are resolved at
+// add-time only — the daemon does not re-resolve.
+func resolveProjectRoots(opts addOptions) ([]string, error) {
+	var roots []string
+	seen := map[string]bool{}
+
+	add := func(p string) error {
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("--project path must be absolute: %q", p)
+		}
+		// Resolve symlinks so the stored root matches what the daemon will
+		// see via proc_pidinfo (which returns realpaths). If the path doesn't
+		// exist we warn-only — a project root might be on an unmounted volume.
+		resolved := filepath.Clean(p)
+		if opts.EvalSymlinks != nil {
+			if r, err := opts.EvalSymlinks(p); err == nil {
+				resolved = r
+			} else {
+				fmt.Fprintf(os.Stderr, "warning: could not resolve %q (%v); storing as-is\n", p, err)
+			}
+		}
+		if seen[resolved] {
+			return nil
+		}
+		seen[resolved] = true
+		roots = append(roots, resolved)
+		return nil
+	}
+
+	if opts.Here {
+		if opts.Getwd == nil {
+			return nil, fmt.Errorf("--here requires a getwd resolver (internal error)")
+		}
+		cwd, err := opts.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("--here: %w", err)
+		}
+		if err := add(cwd); err != nil {
+			return nil, err
+		}
+	}
+	for _, p := range opts.Projects {
+		if err := add(p); err != nil {
+			return nil, err
+		}
+	}
+	return roots, nil
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,216 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubGetwd returns a fixed value, simulating os.Getwd in a deterministic way.
+func stubGetwd(p string) func() (string, error) {
+	return func() (string, error) { return p, nil }
+}
+
+// identitySymlinks is an EvalSymlinks stub that returns the input unchanged.
+// Real symlink resolution is filesystem-bound and not what these tests target.
+func identitySymlinks(p string) (string, error) { return p, nil }
+
+func TestAdd_HereSendsScopeProject(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			return nil, nil
+		},
+	}
+	var stdout bytes.Buffer
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Here:         true,
+		Stdin:        strings.NewReader("ghp_value\n"),
+		Stdout:       &stdout,
+		Getwd:        stubGetwd("/Users/carl/code/proj"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the vault.add call.
+	var addCall *mockCall
+	for i := range mock.calls {
+		if mock.calls[i].Method == "vault.add" {
+			addCall = &mock.calls[i]
+			break
+		}
+	}
+	if addCall == nil {
+		t.Fatal("expected vault.add call")
+	}
+	if got := addCall.Params["scope"]; got != "project" {
+		t.Fatalf("scope: got %v, want project", got)
+	}
+	roots, ok := addCall.Params["roots"].([]string)
+	if !ok {
+		t.Fatalf("roots: expected []string, got %T (%v)", addCall.Params["roots"], addCall.Params["roots"])
+	}
+	if len(roots) != 1 || roots[0] != "/Users/carl/code/proj" {
+		t.Fatalf("roots: got %v, want [/Users/carl/code/proj]", roots)
+	}
+	if !strings.Contains(stdout.String(), "scope: project") {
+		t.Fatalf("stdout should mention project scope, got: %q", stdout.String())
+	}
+}
+
+func TestAdd_MultipleProjectFlagsAccumulate(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			return nil, nil
+		},
+	}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Projects:     []string{"/a", "/b"},
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        stubGetwd("/whatever"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var addCall *mockCall
+	for i := range mock.calls {
+		if mock.calls[i].Method == "vault.add" {
+			addCall = &mock.calls[i]
+		}
+	}
+	if addCall == nil {
+		t.Fatal("expected vault.add")
+	}
+	roots, _ := addCall.Params["roots"].([]string)
+	if len(roots) != 2 || roots[0] != "/a" || roots[1] != "/b" {
+		t.Fatalf("got roots %v, want [/a /b]", roots)
+	}
+}
+
+func TestAdd_HereAndProjectCombine(t *testing.T) {
+	mock := &mockCaller{onCall: func(method string, params map[string]any) (any, error) { return nil, nil }}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Here:         true,
+		Projects:     []string{"/extra"},
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        stubGetwd("/here"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range mock.calls {
+		if c.Method != "vault.add" {
+			continue
+		}
+		roots, _ := c.Params["roots"].([]string)
+		if len(roots) != 2 || roots[0] != "/here" || roots[1] != "/extra" {
+			t.Fatalf("got roots %v, want [/here /extra]", roots)
+		}
+		return
+	}
+	t.Fatal("expected vault.add call")
+}
+
+func TestAdd_NoScopeFlagsLeavesItGlobal(t *testing.T) {
+	mock := &mockCaller{onCall: func(method string, params map[string]any) (any, error) { return nil, nil }}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        stubGetwd("/whatever"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range mock.calls {
+		if c.Method != "vault.add" {
+			continue
+		}
+		if _, ok := c.Params["scope"]; ok {
+			t.Fatalf("global add should not send scope param; params=%v", c.Params)
+		}
+		if _, ok := c.Params["roots"]; ok {
+			t.Fatalf("global add should not send roots param; params=%v", c.Params)
+		}
+		return
+	}
+	t.Fatal("expected vault.add call")
+}
+
+func TestAdd_RejectsRelativeProjectPath(t *testing.T) {
+	mock := &mockCaller{onCall: func(method string, params map[string]any) (any, error) { return nil, nil }}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Projects:     []string{"relative/path"},
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        stubGetwd("/whatever"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err == nil {
+		t.Fatal("expected error for relative path")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("error should mention absolute, got: %v", err)
+	}
+}
+
+func TestAdd_HereGetwdErrorPropagates(t *testing.T) {
+	mock := &mockCaller{onCall: func(method string, params map[string]any) (any, error) { return nil, nil }}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Here:         true,
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        func() (string, error) { return "", errors.New("boom") },
+		EvalSymlinks: identitySymlinks,
+	})
+	if err == nil {
+		t.Fatal("expected error when Getwd fails")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error should propagate, got: %v", err)
+	}
+}
+
+func TestAdd_DuplicateRootsAreDeduplicated(t *testing.T) {
+	mock := &mockCaller{onCall: func(method string, params map[string]any) (any, error) { return nil, nil }}
+	err := runAddWith(mock, addOptions{
+		Name:         "foo",
+		NoInput:      true,
+		Here:         true,
+		Projects:     []string{"/here", "/other"},
+		Stdin:        strings.NewReader("v\n"),
+		Stdout:       &bytes.Buffer{},
+		Getwd:        stubGetwd("/here"),
+		EvalSymlinks: identitySymlinks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range mock.calls {
+		if c.Method != "vault.add" {
+			continue
+		}
+		roots, _ := c.Params["roots"].([]string)
+		if len(roots) != 2 {
+			t.Fatalf("expected 2 unique roots, got %v", roots)
+		}
+	}
+}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"tsm/internal/client"
+	"tsm/internal/jsonrpc"
 )
 
 // mockCaller is a minimal client.Caller for testing get/run command logic.
@@ -179,6 +180,48 @@ func TestGet_FormatUnknownFormatter(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no-such-formatter") {
 		t.Fatalf("error should name the unknown formatter, got: %v", err)
+	}
+}
+
+func TestGet_OutOfScope_ReturnsHintWithBoundRoot(t *testing.T) {
+	rpcErr := &jsonrpc.RPCError{
+		Code:    jsonrpc.CodeSecretOutOfScope,
+		Message: "Secret 'api-key' is project-scoped to a different directory",
+		Data: map[string]any{
+			"name":  "api-key",
+			"roots": []any{"/Users/carl/code/foo"},
+		},
+	}
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			if method == "vault.unlock" {
+				return nil, nil
+			}
+			if method == "vault.get" {
+				return nil, rpcErr
+			}
+			return nil, nil
+		},
+	}
+	err := runGetWith(mock, "api-key", getOptions{
+		Stdout:    &bytes.Buffer{},
+		StdoutTTY: false,
+	})
+	if err == nil {
+		t.Fatal("expected hint error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "api-key") {
+		t.Fatalf("hint should name the secret, got: %v", msg)
+	}
+	if !strings.Contains(msg, "/Users/carl/code/foo") {
+		t.Fatalf("hint should mention the bound root, got: %v", msg)
+	}
+	if !strings.Contains(msg, "cd into that directory") {
+		t.Fatalf("hint should suggest cd, got: %v", msg)
+	}
+	if !strings.Contains(msg, "tsm list --all") {
+		t.Fatalf("hint should mention 'tsm list --all', got: %v", msg)
 	}
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"golang.org/x/term"
 
@@ -76,10 +77,43 @@ func formatRPCError(err *jsonrpc.RPCError) string {
 		return fmt.Sprintf("%s\nAuthenticate via Touch ID to proceed.", err.Message)
 	case jsonrpc.CodeSecretNotFound:
 		return fmt.Sprintf("%s\nRun 'tsm list' to see available secrets.", err.Message)
+	case jsonrpc.CodeSecretOutOfScope:
+		// Daemon includes {name, roots} in data so we can render an
+		// actionable hint: which secret, where it's bound, what to do.
+		name, _ := err.Data["name"].(string)
+		roots := stringSliceFromData(err.Data["roots"])
+		rootsStr := ""
+		if len(roots) > 0 {
+			rootsStr = roots[0]
+			if len(roots) > 1 {
+				rootsStr += " (or one of: " + strings.Join(roots, ", ") + ")"
+			}
+		}
+		return fmt.Sprintf(
+			"Secret %q is project-scoped to %s. cd into that directory to access it. Use 'tsm list --all' to see all bindings.",
+			name, rootsStr,
+		)
 	default:
 		return err.Message
 	}
 }
+
+// stringSliceFromData unpacks a JSON array of strings out of an RPC error's
+// untyped `data` map. Tolerant of nil and unexpected shapes.
+func stringSliceFromData(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 
 // handleError formats and prints an error, returning it for cobra.
 func handleError(err error) error {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"tsm/internal/client"
@@ -15,32 +17,58 @@ type secretMetadata struct {
 	Description string   `json:"description"`
 	Confirm     bool     `json:"confirm"`
 	Tags        []string `json:"tags"`
+	Scope       string   `json:"scope"`
+	Roots       []string `json:"roots"`
+}
+
+// listOptions captures inputs for runListWith. Extracted for testability.
+type listOptions struct {
+	All    bool
+	Stdout io.Writer
 }
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets (names and descriptions, never values)",
+		Long: `List secrets visible to the current directory.
+
+By default, project-scoped secrets bound to other directories are hidden —
+this prevents an agent from seeing secret names it has no business with.
+Pass --all to enumerate every secret regardless of project binding.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			all, _ := cmd.Flags().GetBool("all")
 			return withUnlockedClient(func(c client.Caller) error {
-				return runList(c)
+				return runListWith(c, listOptions{All: all, Stdout: os.Stdout})
 			})
 		},
 	}
+	cmd.Flags().Bool("all", false, "include project-scoped secrets bound to other directories")
+	return cmd
 }
 
-func runList(c client.Caller) error {
+func runListWith(c client.Caller, opts listOptions) error {
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	params := map[string]any{}
+	if opts.All {
+		params["include_all"] = true
+	}
+
 	var secrets []secretMetadata
-	if err := c.Call("vault.list", nil, &secrets); err != nil {
+	if err := c.Call("vault.list", params, &secrets); err != nil {
 		return handleError(err)
 	}
 
 	if jsonOutput() {
-		return printJSON(secrets)
+		return printJSONTo(stdout, secrets)
 	}
 
 	if len(secrets) == 0 {
-		fmt.Println("No secrets stored. Run 'tsm add' to add one.")
+		fmt.Fprintln(stdout, "No secrets stored. Run 'tsm add' to add one.")
 		return nil
 	}
 
@@ -57,12 +85,15 @@ func runList(c client.Caller) error {
 		if s.DisplayName != "" && s.DisplayName != s.Name {
 			label = s.DisplayName
 		}
-		fmt.Printf("  %s%s%s\n", label, confirm, tags)
+		fmt.Fprintf(stdout, "  %s%s%s\n", label, confirm, tags)
 		if s.DisplayName != "" && s.DisplayName != s.Name {
-			fmt.Printf("    id: %s\n", s.Name)
+			fmt.Fprintf(stdout, "    id: %s\n", s.Name)
 		}
 		if s.Description != "" {
-			fmt.Printf("    %s\n", s.Description)
+			fmt.Fprintf(stdout, "    %s\n", s.Description)
+		}
+		if s.Scope == "project" && len(s.Roots) > 0 {
+			fmt.Fprintf(stdout, "    scope: project (%s)\n", strings.Join(s.Roots, ", "))
 		}
 	}
 	return nil

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestList_DefaultDoesNotSendIncludeAll(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			if method == "vault.list" {
+				if _, ok := params["include_all"]; ok {
+					t.Fatalf("default list must not pass include_all; got params=%v", params)
+				}
+				return []secretMetadata{}, nil
+			}
+			return nil, nil
+		},
+	}
+	if err := runListWith(mock, listOptions{Stdout: &bytes.Buffer{}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestList_AllSendsIncludeAll(t *testing.T) {
+	var sawIncludeAll bool
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			if method == "vault.list" {
+				if v, ok := params["include_all"]; ok && v == true {
+					sawIncludeAll = true
+				}
+				return []secretMetadata{}, nil
+			}
+			return nil, nil
+		},
+	}
+	if err := runListWith(mock, listOptions{All: true, Stdout: &bytes.Buffer{}}); err != nil {
+		t.Fatal(err)
+	}
+	if !sawIncludeAll {
+		t.Fatal("--all should pass include_all=true to vault.list")
+	}
+}
+
+func TestList_RendersScopeLineForProjectSecret(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			if method == "vault.list" {
+				return []secretMetadata{
+					{Name: "proj-key", Description: "test", Scope: "project", Roots: []string{"/Users/carl/code/foo"}},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+	var buf bytes.Buffer
+	if err := runListWith(mock, listOptions{Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "scope: project (/Users/carl/code/foo)") {
+		t.Fatalf("expected scope line, got:\n%s", out)
+	}
+}
+
+func TestList_GlobalSecretHasNoScopeLine(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			if method == "vault.list" {
+				return []secretMetadata{
+					{Name: "global-key", Description: "g", Scope: "global"},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+	var buf bytes.Buffer
+	if err := runListWith(mock, listOptions{Stdout: &buf}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "scope:") {
+		t.Fatalf("global secret should not render scope line; got:\n%s", buf.String())
+	}
+}
+
+func TestList_PropagatesRPCError(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			return nil, errors.New("boom")
+		},
+	}
+	err := runListWith(mock, listOptions{Stdout: &bytes.Buffer{}})
+	if err == nil {
+		t.Fatal("expected error to bubble up")
+	}
+}

--- a/internal/jsonrpc/types.go
+++ b/internal/jsonrpc/types.go
@@ -39,7 +39,8 @@ func (e *RPCError) Error() string {
 
 // Well-known tsm error codes.
 const (
-	CodeVaultLocked    = -32001
-	CodeAuthRequired   = -32002
-	CodeSecretNotFound = -32003
+	CodeVaultLocked      = -32001
+	CodeAuthRequired     = -32002
+	CodeSecretNotFound   = -32003
+	CodeSecretOutOfScope = -32010
 )

--- a/plugin/skills/credential-usage/SKILL.md
+++ b/plugin/skills/credential-usage/SKILL.md
@@ -18,6 +18,22 @@ tsm list --json
 
 If `tsm list` shows the credential, use it via one of the patterns below. Only ask the user if no matching secret exists.
 
+## 1a. Project-scoped secrets
+
+Some secrets are bound to a project directory. They appear in `tsm list` only when the cwd is inside the project's bound root, and `tsm get` returns `secret_out_of_scope` (RPC error code -32010) from anywhere else.
+
+- **Default `tsm list --json` is already cwd-filtered.** Trust it. Use `tsm list --all --json` only when explicitly asked to enumerate everything; that result still excludes secret values.
+- A project-scoped secret carries `"scope": "project"` and `"roots": ["/abs/path", ...]` in `tsm list` output.
+- When `tsm get foo` fails with `secret_out_of_scope`, do **not** suggest `cd`-ing elsewhere to fetch it — explain to the user that the secret is bound to a different project, and let them decide whether to re-scope it. Offer to use `tsm list --all` to find out where it lives.
+- Saving a project-bound secret on the user's behalf: the user must be `cd`'d into the project root, then run
+
+  ```bash
+  pbpaste | tsm add --no-input --here --name <kebab-id> --display-name "<...>"
+  ```
+
+  Use `--project /abs/path` (repeatable) instead of `--here` if the user wants to bind to a directory other than their cwd.
+- Project scoping is a **UX boundary, not a security boundary.** Within the user's account, any process can `chdir(...)` before talking to tsm and the daemon will faithfully report the spoofed cwd. Don't rely on it for authorization — its value is preventing accidents and reducing blast radius from supply-chain compromise within a project.
+
 ## 2. Pattern by tool category
 
 Pick the pattern that matches the consuming tool. Never fall back to a less safe pattern just because it is shorter.

--- a/tsmd/Sources/tsmd/JSONRPCHandler.swift
+++ b/tsmd/Sources/tsmd/JSONRPCHandler.swift
@@ -7,9 +7,9 @@ actor JSONRPCHandler {
         self.vault = vault
     }
 
-    func handle(_ request: JSONRPCRequest, sessionID: pid_t) async -> JSONRPCResponse {
+    func handle(_ request: JSONRPCRequest, sessionID: pid_t, peerCwd: String? = nil) async -> JSONRPCResponse {
         do {
-            let result = try await dispatch(request, sessionID: sessionID)
+            let result = try await dispatch(request, sessionID: sessionID, peerCwd: peerCwd)
             return JSONRPCResponse(result: result, id: request.id)
         } catch let error as VaultError {
             return JSONRPCResponse(error: mapVaultError(error), id: request.id)
@@ -26,7 +26,7 @@ actor JSONRPCHandler {
         }
     }
 
-    private func dispatch(_ req: JSONRPCRequest, sessionID: pid_t) async throws -> JSONValue {
+    private func dispatch(_ req: JSONRPCRequest, sessionID: pid_t, peerCwd: String?) async throws -> JSONValue {
         switch req.method {
         case "vault.init":
             let passphrase = req.stringParam("recovery_passphrase")
@@ -52,7 +52,11 @@ actor JSONRPCHandler {
             return encodeToJSONValue(status)
 
         case "vault.list":
-            let secrets = try await vault.list(sessionID: sessionID)
+            // include_all bypasses the cwd filter and returns every secret —
+            // the CLI uses it for `tsm list --all`. Default is the safer
+            // cwd-filtered view.
+            let includeAll = req.param("include_all")?.boolValue ?? false
+            let secrets = try await vault.list(sessionID: sessionID, peerCwd: peerCwd, includeAll: includeAll)
             return encodeToJSONValue(secrets)
 
         case "vault.get":
@@ -60,7 +64,8 @@ actor JSONRPCHandler {
                 throw VaultError.invalidName("Missing 'name' parameter")
             }
             let clientId = req.stringParam("client_id")
-            let secret = try await vault.get(name: name, sessionID: sessionID, clientId: clientId)
+            let secret = try await vault.get(name: name, sessionID: sessionID,
+                                             peerCwd: peerCwd, clientId: clientId)
             return .object(["name": .string(secret.name), "value": .string(secret.value)])
 
         case "vault.add":
@@ -77,9 +82,17 @@ actor JSONRPCHandler {
                 }
                 return []
             }()
+            let scope = req.stringParam("scope") ?? SecretScope.global
+            let roots: [String] = {
+                if case .array(let arr) = req.param("roots") {
+                    return arr.compactMap { $0.stringValue }
+                }
+                return []
+            }()
             let clientId = req.stringParam("client_id")
             try await vault.add(name: name, displayName: displayName, value: value,
                                description: description, confirm: confirm, tags: tags,
+                               scope: scope, roots: roots,
                                sessionID: sessionID, clientId: clientId)
             return .object(["ok": .bool(true)])
 
@@ -187,6 +200,19 @@ actor JSONRPCHandler {
             return JSONRPCError(
                 code: RPCErrorCode.invalidParams,
                 message: msg
+            )
+        case .secretOutOfScope(let name, let roots):
+            // The CLI reads `name` and `roots` out of `data` to render the
+            // hint message. Keeping the data structured (not folded into the
+            // human-readable `message`) lets future tools localize or format
+            // it differently.
+            return JSONRPCError(
+                code: RPCErrorCode.secretOutOfScope,
+                message: "Secret '\(name)' is project-scoped to a different directory",
+                data: [
+                    "name": .string(name),
+                    "roots": .array(roots.map { .string($0) }),
+                ]
             )
         }
     }

--- a/tsmd/Sources/tsmd/JSONRPCTypes.swift
+++ b/tsmd/Sources/tsmd/JSONRPCTypes.swift
@@ -122,4 +122,7 @@ enum RPCErrorCode {
     static let vaultLocked = -32001
     static let authRequired = -32002
     static let secretNotFound = -32003
+    /// The named secret exists but the calling peer's cwd is outside the
+    /// project root(s) it is bound to. The CLI surfaces this as a hint.
+    static let secretOutOfScope = -32010
 }

--- a/tsmd/Sources/tsmd/Models.swift
+++ b/tsmd/Sources/tsmd/Models.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+// Sentinel scope values stored on `Secret.scope`. Kept as plain strings (not
+// an enum) so older vault JSON forward-decodes without crashing if a future
+// scope variant lands.
+enum SecretScope {
+    static let global = "global"
+    static let project = "project"
+}
+
 struct Secret: Codable, Equatable, Sendable {
     let name: String
     var displayName: String
@@ -10,13 +18,20 @@ struct Secret: Codable, Equatable, Sendable {
     let created: Date
     var updated: Date?
 
+    // Project-scoping. `scope == "global"` ignores `roots`. `scope == "project"`
+    // restricts the secret to peers whose cwd is inside any of `roots`.
+    var scope: String
+    var roots: [String]
+
     enum CodingKeys: String, CodingKey {
         case name, value, description, confirm, tags, created, updated
         case displayName = "display_name"
+        case scope, roots
     }
 
     init(name: String, displayName: String = "", value: String, description: String = "",
-         confirm: Bool = false, tags: [String] = [], created: Date, updated: Date? = nil) {
+         confirm: Bool = false, tags: [String] = [], created: Date, updated: Date? = nil,
+         scope: String = SecretScope.global, roots: [String] = []) {
         self.name = name
         self.displayName = displayName
         self.value = value
@@ -25,10 +40,13 @@ struct Secret: Codable, Equatable, Sendable {
         self.tags = tags
         self.created = created
         self.updated = updated
+        self.scope = scope
+        self.roots = roots
     }
 
-    // Custom decoder so vault files written before display_name was a field
-    // decode cleanly with displayName == "".
+    // Custom decoder so vault files written before display_name / scope / roots
+    // existed decode cleanly with the documented defaults. No envelope-version
+    // bump: the format is structurally identical and the new fields are additive.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try c.decode(String.self, forKey: .name)
@@ -39,6 +57,8 @@ struct Secret: Codable, Equatable, Sendable {
         self.tags = try c.decode([String].self, forKey: .tags)
         self.created = try c.decode(Date.self, forKey: .created)
         self.updated = try c.decodeIfPresent(Date.self, forKey: .updated)
+        self.scope = (try? c.decodeIfPresent(String.self, forKey: .scope)) ?? SecretScope.global
+        self.roots = (try? c.decodeIfPresent([String].self, forKey: .roots)) ?? []
     }
 }
 
@@ -48,9 +68,11 @@ struct SecretMetadata: Codable, Equatable, Sendable {
     let description: String
     let confirm: Bool
     let tags: [String]
+    let scope: String
+    let roots: [String]
 
     enum CodingKeys: String, CodingKey {
-        case name, description, confirm, tags
+        case name, description, confirm, tags, scope, roots
         case displayName = "display_name"
     }
 
@@ -60,6 +82,8 @@ struct SecretMetadata: Codable, Equatable, Sendable {
         self.description = secret.description
         self.confirm = secret.confirm
         self.tags = secret.tags
+        self.scope = secret.scope
+        self.roots = secret.roots
     }
 }
 

--- a/tsmd/Sources/tsmd/PeerCwd.swift
+++ b/tsmd/Sources/tsmd/PeerCwd.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Darwin
+
+/// Closure type matching `proc_pidinfo`'s signature, exposed so tests can
+/// inject a fake without touching the kernel. The real production callsite
+/// uses `proc_pidinfo` directly.
+typealias ProcPidInfoFn = (pid_t, Int32, UInt64, UnsafeMutableRawPointer?, Int32) -> Int32
+
+enum PeerCwd {
+    /// Return the connecting peer process's current working directory by
+    /// asking the kernel via `proc_pidinfo(PROC_PIDVNODEPATHINFO)`.
+    ///
+    /// Why the daemon does this rather than letting the CLI claim its cwd:
+    /// the CLI is untrusted in this dimension. A malicious binary could
+    /// trivially send `cwd=/somewhere/else` to exfiltrate scoped secrets.
+    /// The kernel's view, indexed by the peer's real pid (already pulled
+    /// from `LOCAL_PEERPID` upstream), is the only honest source.
+    ///
+    /// Returns nil when the kernel call fails or the process has gone
+    /// away mid-call. Callers should treat nil as "out of scope" — global
+    /// secrets remain accessible, project-scoped secrets do not.
+    ///
+    /// The closure injection mirrors `PeerSession.resolveDurableSessionID`'s
+    /// `sessionOf` / `parentOf` parameters so the test suite can fake the
+    /// syscall layer.
+    static func resolve(
+        peerPID: pid_t,
+        proc: ProcPidInfoFn = { proc_pidinfo($0, $1, $2, $3, $4) }
+    ) -> String? {
+        var info = proc_vnodepathinfo()
+        let stride = MemoryLayout<proc_vnodepathinfo>.stride
+        let rc = withUnsafeMutablePointer(to: &info) { ptr -> Int32 in
+            proc(peerPID, PROC_PIDVNODEPATHINFO, 0, UnsafeMutableRawPointer(ptr), Int32(stride))
+        }
+        // The kernel writes exactly `stride` bytes on success. Anything less
+        // means a truncated read or process-gone, both of which we fail closed on.
+        guard rc >= Int32(stride) else { return nil }
+
+        // `vip_path` is a fixed-size NUL-terminated C string of MAXPATHLEN.
+        let path: String = withUnsafeBytes(of: &info.pvi_cdir.vip_path) { raw -> String in
+            // Find the NUL terminator and decode the prefix as UTF-8.
+            let bytes = raw.bindMemory(to: UInt8.self)
+            var len = 0
+            while len < bytes.count && bytes[len] != 0 { len += 1 }
+            return String(decoding: UnsafeBufferPointer(rebasing: bytes[0..<len]), as: UTF8.self)
+        }
+        guard !path.isEmpty else { return nil }
+        return path
+    }
+}

--- a/tsmd/Sources/tsmd/SocketServer.swift
+++ b/tsmd/Sources/tsmd/SocketServer.swift
@@ -30,12 +30,17 @@ final class SocketServer: @unchecked Sendable {
     // (LOCAL_PEEREPID) is not relevant here because setsid affects real and
     // effective sessions equally and we want session-id resolution to follow
     // the peer's actual process, not whatever setuid masquerade is in effect.
-    private func peerSessionID(fd: Int32) -> pid_t? {
+    /// Resolve the peer pid + durable session id for the connection. Cwd is
+    /// deliberately *not* captured here — it's resolved per-RPC in
+    /// `handleConnection` so each call sees the kernel's current view (a
+    /// long-lived connection might outlive a `cd`).
+    private func peerInfo(fd: Int32) -> (peerPID: pid_t, sessionID: pid_t)? {
         var pid: pid_t = 0
         var len = socklen_t(MemoryLayout<pid_t>.size)
         let rc = getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID, &pid, &len)
         guard rc == 0, pid > 0 else { return nil }
-        return PeerSession.resolveDurableSessionID(peerPID: pid)
+        guard let sid = PeerSession.resolveDurableSessionID(peerPID: pid) else { return nil }
+        return (pid, sid)
     }
 
     func start() throws {
@@ -82,11 +87,11 @@ final class SocketServer: @unchecked Sendable {
             guard let self = self else { return }
             let clientFd = accept(self.serverFd, nil, nil)
             guard clientFd >= 0 else { return }
-            guard let sid = self.peerSessionID(fd: clientFd) else {
+            guard let info = self.peerInfo(fd: clientFd) else {
                 close(clientFd)
                 return
             }
-            Task { await self.handleConnection(clientFd, sessionID: sid) }
+            Task { await self.handleConnection(clientFd, peerPID: info.peerPID, sessionID: info.sessionID) }
         }
         source.setCancelHandler { [serverFd = self.serverFd] in
             close(serverFd)
@@ -101,7 +106,7 @@ final class SocketServer: @unchecked Sendable {
         unlink(socketPath)
     }
 
-    private func handleConnection(_ fd: Int32, sessionID: pid_t) async {
+    private func handleConnection(_ fd: Int32, peerPID: pid_t, sessionID: pid_t) async {
         defer { close(fd) }
 
         var buffer = Data()
@@ -137,7 +142,11 @@ final class SocketServer: @unchecked Sendable {
                     continue
                 }
 
-                let response = await handler.handle(request, sessionID: sessionID)
+                // Per-RPC peer-cwd lookup. A long-lived connection may
+                // outlive a `cd`, so we re-ask the kernel each time rather
+                // than caching at accept().
+                let peerCwd = PeerCwd.resolve(peerPID: peerPID)
+                let response = await handler.handle(request, sessionID: sessionID, peerCwd: peerCwd)
                 writeResponse(response, to: fd)
 
                 if request.method == "daemon.shutdown" {

--- a/tsmd/Sources/tsmd/Vault.swift
+++ b/tsmd/Sources/tsmd/Vault.swift
@@ -11,7 +11,11 @@ enum VaultError: Error, Equatable {
     case authRequired
     case authFailed
     case invalidName(String)
-    case invalidConfig(String)   // NEW
+    case invalidConfig(String)
+    /// The named secret exists but is project-scoped to roots that do not
+    /// contain the calling peer's cwd. Carries the secret name and the bound
+    /// roots so the CLI can render an actionable hint.
+    case secretOutOfScope(name: String, roots: [String])
 }
 
 // MARK: - Dependency protocols
@@ -60,6 +64,69 @@ enum DisplayNameValidation {
         for ch in s.unicodeScalars where ch.value < 0x20 || ch.value == 0x7F {
             throw VaultError.invalidName("Display name cannot contain control characters")
         }
+    }
+}
+
+// MARK: - Scope validation / matching
+
+enum ScopeValidation {
+    static let maxRoots = 16
+
+    /// Validate the scope+roots tuple supplied to vault.add. Returns the
+    /// normalized roots on success (trailing slash stripped, but no symlink
+    /// resolution — that happens client-side at add time).
+    static func validate(scope: String, roots: [String]) throws -> [String] {
+        switch scope {
+        case SecretScope.global:
+            guard roots.isEmpty else {
+                throw VaultError.invalidConfig("scope=global must have empty roots")
+            }
+            return []
+        case SecretScope.project:
+            guard !roots.isEmpty else {
+                throw VaultError.invalidConfig("scope=project requires at least one root")
+            }
+            guard roots.count <= maxRoots else {
+                throw VaultError.invalidConfig("scope=project supports at most \(maxRoots) roots")
+            }
+            return try roots.map { try normalizeRoot($0) }
+        default:
+            throw VaultError.invalidConfig("unknown scope '\(scope)' (expected 'global' or 'project')")
+        }
+    }
+
+    /// Normalize a single root: must be absolute, no `..` components, no
+    /// trailing slash (except the root "/").
+    static func normalizeRoot(_ raw: String) throws -> String {
+        guard raw.hasPrefix("/") else {
+            throw VaultError.invalidConfig("root must be absolute: '\(raw)'")
+        }
+        let components = raw.split(separator: "/", omittingEmptySubsequences: false)
+        for comp in components where comp == ".." || comp == "." {
+            throw VaultError.invalidConfig("root must be normalized (no '.' or '..' components): '\(raw)'")
+        }
+        // Strip trailing slash unless the path *is* "/".
+        if raw == "/" { return "/" }
+        if raw.hasSuffix("/") { return String(raw.dropLast()) }
+        return raw
+    }
+}
+
+enum ScopeMatcher {
+    /// True when `cwd` is inside `root` (or equal to it). Both inputs assumed
+    /// to be normalized absolute paths. The boundary check guards against
+    /// `/foo` matching `/foobar`.
+    static func cwdMatchesRoot(cwd: String, root: String) -> Bool {
+        if cwd == root { return true }
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        return cwd.hasPrefix(prefix)
+    }
+
+    /// True when `cwd` is in any of the secret's roots.
+    static func inScope(secret: Secret, cwd: String?) -> Bool {
+        if secret.scope == SecretScope.global { return true }
+        guard let cwd = cwd else { return false }
+        return secret.roots.contains(where: { cwdMatchesRoot(cwd: cwd, root: $0) })
     }
 }
 
@@ -197,18 +264,34 @@ actor Vault {
 
     // MARK: - CRUD
 
-    func list(sessionID: pid_t) throws -> [SecretMetadata] {
+    /// List secrets visible to the calling peer.
+    /// - When `includeAll` is true, returns every secret regardless of scope.
+    ///   The CLI uses this for `tsm list --all`.
+    /// - Otherwise, returns global secrets plus project-scoped secrets whose
+    ///   roots include `peerCwd`. Project secrets bound elsewhere are filtered
+    ///   out so an agent in /Users/carl/code/A doesn't even see the names of
+    ///   secrets bound to /Users/carl/code/B.
+    func list(sessionID: pid_t, peerCwd: String? = nil, includeAll: Bool = false) throws -> [SecretMetadata] {
         try authorized(sessionID)
-        return data!.secrets.map { SecretMetadata(from: $0) }
+        let secrets = data!.secrets.filter { secret in
+            if includeAll { return true }
+            return ScopeMatcher.inScope(secret: secret, cwd: peerCwd)
+        }
+        return secrets.map { SecretMetadata(from: $0) }
     }
 
-    func get(name: String, sessionID: pid_t, clientId: String? = nil) async throws -> Secret {
+    func get(name: String, sessionID: pid_t, peerCwd: String? = nil,
+             clientId: String? = nil) async throws -> Secret {
         try authorized(sessionID)
         guard let secret = data!.secrets.first(where: {
             $0.name.lowercased() == name.lowercased()
         }) else {
             try? accessLog.log(method: "vault.get", secret: name, clientId: clientId, result: "not_found")
             throw VaultError.secretNotFound(name)
+        }
+        if !ScopeMatcher.inScope(secret: secret, cwd: peerCwd) {
+            try? accessLog.log(method: "vault.get", secret: name, clientId: clientId, result: "out_of_scope")
+            throw VaultError.secretOutOfScope(name: secret.name, roots: secret.roots)
         }
         if secret.confirm {
             try await auth.authenticate(reason: "Access secret '\(name)'")
@@ -219,16 +302,19 @@ actor Vault {
 
     func add(name: String, displayName: String = "", value: String, description: String,
              confirm: Bool = false, tags: [String] = [],
+             scope: String = SecretScope.global, roots: [String] = [],
              sessionID: pid_t, clientId: String? = nil) async throws {
         try authorized(sessionID)
         try NameValidation.validate(name)
         try DisplayNameValidation.validate(displayName)
+        let normalizedRoots = try ScopeValidation.validate(scope: scope, roots: roots)
         guard !data!.secrets.contains(where: { $0.name.lowercased() == name.lowercased() }) else {
             throw VaultError.secretAlreadyExists(name)
         }
         let secret = Secret(
             name: name, displayName: displayName, value: value, description: description,
-            confirm: confirm, tags: tags, created: Date()
+            confirm: confirm, tags: tags, created: Date(),
+            scope: scope, roots: normalizedRoots
         )
         data!.secrets.append(secret)
         try persist()

--- a/tsmd/Tests/tsmdTests/JSONRPCHandlerTests.swift
+++ b/tsmd/Tests/tsmdTests/JSONRPCHandlerTests.swift
@@ -179,6 +179,102 @@ final class JSONRPCHandlerTests: XCTestCase {
         XCTAssertNil(resp.error)
     }
 
+    // MARK: - Project scoping (peer cwd plumbed through dispatch)
+
+    func testAddProjectScopeAndGetInScope() async {
+        _ = await handler.handle(makeRequest(method: "vault.init"), sessionID: sid)
+        let addResp = await handler.handle(makeRequest(
+            method: "vault.add",
+            params: [
+                "name": .string("proj-key"),
+                "value": .string("v"),
+                "description": .string("d"),
+                "scope": .string("project"),
+                "roots": .array([.string("/tmp/foo")]),
+            ]
+        ), sessionID: sid)
+        XCTAssertNil(addResp.error, addResp.error?.message ?? "")
+
+        let getInScope = await handler.handle(makeRequest(
+            method: "vault.get",
+            params: ["name": .string("proj-key")]
+        ), sessionID: sid, peerCwd: "/tmp/foo/sub")
+        XCTAssertNil(getInScope.error)
+    }
+
+    func testGetProjectScopedSecretOutOfScopeReturnsErrorWithRootsData() async {
+        _ = await handler.handle(makeRequest(method: "vault.init"), sessionID: sid)
+        _ = await handler.handle(makeRequest(
+            method: "vault.add",
+            params: [
+                "name": .string("proj-key"),
+                "value": .string("v"),
+                "description": .string("d"),
+                "scope": .string("project"),
+                "roots": .array([.string("/tmp/foo")]),
+            ]
+        ), sessionID: sid)
+
+        let resp = await handler.handle(makeRequest(
+            method: "vault.get",
+            params: ["name": .string("proj-key")]
+        ), sessionID: sid, peerCwd: "/tmp/elsewhere")
+
+        XCTAssertEqual(resp.error?.code, RPCErrorCode.secretOutOfScope)
+        XCTAssertEqual(resp.error?.code, -32010, "the wire-format error code is part of the contract")
+        guard let data = resp.error?.data else { return XCTFail("expected data field") }
+        XCTAssertEqual(data["name"], .string("proj-key"))
+        XCTAssertEqual(data["roots"], .array([.string("/tmp/foo")]))
+    }
+
+    func testListWithIncludeAllReturnsOutOfScopeProjectSecrets() async {
+        _ = await handler.handle(makeRequest(method: "vault.init"), sessionID: sid)
+        _ = await handler.handle(makeRequest(
+            method: "vault.add",
+            params: [
+                "name": .string("proj-key"),
+                "value": .string("v"),
+                "description": .string("d"),
+                "scope": .string("project"),
+                "roots": .array([.string("/tmp/foo")]),
+            ]
+        ), sessionID: sid)
+
+        // Without include_all and from out-of-scope cwd, the project secret is hidden.
+        let filtered = await handler.handle(makeRequest(method: "vault.list"), sessionID: sid, peerCwd: "/elsewhere")
+        if case .array(let arr) = filtered.result {
+            XCTAssertTrue(arr.isEmpty, "out-of-scope project secret leaked into default list")
+        } else {
+            XCTFail("expected array")
+        }
+
+        // With include_all, the project secret comes back.
+        let all = await handler.handle(makeRequest(
+            method: "vault.list",
+            params: ["include_all": .bool(true)]
+        ), sessionID: sid, peerCwd: "/elsewhere")
+        if case .array(let arr) = all.result {
+            XCTAssertEqual(arr.count, 1)
+        } else {
+            XCTFail("expected array")
+        }
+    }
+
+    func testAddProjectScopeWithEmptyRootsReturnsInvalidParams() async {
+        _ = await handler.handle(makeRequest(method: "vault.init"), sessionID: sid)
+        let resp = await handler.handle(makeRequest(
+            method: "vault.add",
+            params: [
+                "name": .string("k"),
+                "value": .string("v"),
+                "description": .string("d"),
+                "scope": .string("project"),
+                "roots": .array([]),
+            ]
+        ), sessionID: sid)
+        XCTAssertEqual(resp.error?.code, RPCErrorCode.invalidParams)
+    }
+
     // MARK: - Session isolation
 
     func testHandlerThreadsSessionIDIntoVaultCalls() async throws {

--- a/tsmd/Tests/tsmdTests/ModelsTests.swift
+++ b/tsmd/Tests/tsmdTests/ModelsTests.swift
@@ -105,6 +105,55 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(s.name, "old-secret")
     }
 
+    func testSecret_ScopeRoots_BackwardCompat() throws {
+        // Vault rows written before scope/roots existed must decode to the
+        // documented defaults: scope="global", roots=[]. The custom decoder
+        // owns that contract; no envelope-version bump is involved.
+        let oldJSON = #"""
+        {"name":"legacy","value":"v","description":"d","confirm":false,"tags":[],"created":"2025-01-01T00:00:00Z"}
+        """#.data(using: .utf8)!
+        let s = try decoder.decode(Secret.self, from: oldJSON)
+        XCTAssertEqual(s.scope, "global")
+        XCTAssertEqual(s.roots, [])
+    }
+
+    func testSecret_ScopeRoots_RoundTrip() throws {
+        let secret = Secret(
+            name: "scoped",
+            value: "v",
+            description: "d",
+            confirm: false,
+            tags: [],
+            created: Date(timeIntervalSince1970: 1_700_000_000),
+            updated: nil,
+            scope: SecretScope.project,
+            roots: ["/Users/carl/code/foo", "/Users/carl/code/bar"]
+        )
+        let data = try encoder.encode(secret)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"scope\":\"project\""), json)
+        // JSONEncoder may escape '/' as '\/' depending on flags; check both.
+        XCTAssertTrue(json.contains("/Users/carl/code/foo") ||
+                      json.contains("\\/Users\\/carl\\/code\\/foo"), json)
+        let decoded = try decoder.decode(Secret.self, from: data)
+        XCTAssertEqual(decoded, secret)
+    }
+
+    func testSecretMetadata_CarriesScopeAndRoots() throws {
+        let secret = Secret(
+            name: "k", value: "v", description: "d",
+            confirm: false, tags: [], created: Date(),
+            scope: SecretScope.project, roots: ["/tmp/foo"]
+        )
+        let meta = SecretMetadata(from: secret)
+        XCTAssertEqual(meta.scope, "project")
+        XCTAssertEqual(meta.roots, ["/tmp/foo"])
+        let data = try encoder.encode(meta)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"scope\":\"project\""), json)
+        XCTAssertTrue(json.contains("/tmp/foo") || json.contains("\\/tmp\\/foo"), json)
+    }
+
     func testSecretMetadata_CarriesDisplayName() throws {
         let secret = Secret(
             name: "k", displayName: "Kebab Display",

--- a/tsmd/Tests/tsmdTests/PeerCwdTests.swift
+++ b/tsmd/Tests/tsmdTests/PeerCwdTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import Darwin
+@testable import tsmd
+
+final class PeerCwdTests: XCTestCase {
+    /// Build a fake `proc_pidinfo` that writes a `proc_vnodepathinfo` whose
+    /// `pvi_cdir.vip_path` contains the given UTF-8 string.
+    private func fakeProc(returningPath path: String, bytesReturned: Int32? = nil) -> ProcPidInfoFn {
+        return { _, flavor, _, buffer, bufsize in
+            guard flavor == PROC_PIDVNODEPATHINFO else { return -1 }
+            let stride = MemoryLayout<proc_vnodepathinfo>.stride
+            guard Int(bufsize) >= stride, let buffer = buffer else { return -1 }
+            // Zero the destination, then memcpy the path bytes (NUL-terminated).
+            memset(buffer, 0, stride)
+            let info = buffer.assumingMemoryBound(to: proc_vnodepathinfo.self)
+            withUnsafeMutableBytes(of: &info.pointee.pvi_cdir.vip_path) { dst in
+                let bytes = path.utf8CString
+                let limit = min(bytes.count, dst.count)
+                for i in 0..<limit {
+                    dst[i] = UInt8(bitPattern: bytes[i])
+                }
+            }
+            return bytesReturned ?? Int32(stride)
+        }
+    }
+
+    private func failingProc(rc: Int32 = 0) -> ProcPidInfoFn {
+        return { _, _, _, _, _ in rc }
+    }
+
+    func testResolveReturnsCwdString() {
+        let result = PeerCwd.resolve(peerPID: 1234, proc: fakeProc(returningPath: "/tmp/foo"))
+        XCTAssertEqual(result, "/tmp/foo")
+    }
+
+    func testResolveHandlesLongPathNearMaxPathLen() {
+        // Construct a path comfortably long but well under MAXPATHLEN (1024 on Darwin).
+        let component = String(repeating: "a", count: 50)
+        let path = "/" + Array(repeating: component, count: 12).joined(separator: "/")
+        let result = PeerCwd.resolve(peerPID: 1234, proc: fakeProc(returningPath: path))
+        XCTAssertEqual(result, path)
+    }
+
+    func testResolveReturnsNilOnZeroReturn() {
+        // proc_pidinfo returning 0 means the process is gone or the call failed.
+        let result = PeerCwd.resolve(peerPID: 1234, proc: failingProc(rc: 0))
+        XCTAssertNil(result)
+    }
+
+    func testResolveReturnsNilOnShortReturn() {
+        // A short return means the kernel didn't fill the struct; fail closed.
+        let result = PeerCwd.resolve(peerPID: 1234,
+                                     proc: fakeProc(returningPath: "/tmp/foo", bytesReturned: 4))
+        XCTAssertNil(result)
+    }
+
+    func testResolveReturnsNilOnEmptyPath() {
+        // An empty cwd (no NUL-prefixed string) shouldn't be treated as scope-matching root "/".
+        let result = PeerCwd.resolve(peerPID: 1234, proc: fakeProc(returningPath: ""))
+        XCTAssertNil(result)
+    }
+}

--- a/tsmd/Tests/tsmdTests/VaultTests.swift
+++ b/tsmd/Tests/tsmdTests/VaultTests.swift
@@ -349,6 +349,169 @@ final class VaultTests: XCTestCase {
         }
     }
 
+    // MARK: - Project scoping
+
+    func testAddProjectScopeRejectsEmptyRoots() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        do {
+            try await vault.add(name: "k", value: "v", description: "d",
+                                scope: "project", roots: [], sessionID: sidA)
+            XCTFail("expected invalidConfig")
+        } catch VaultError.invalidConfig {
+            // expected
+        }
+    }
+
+    func testAddRejectsUnknownScope() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        do {
+            try await vault.add(name: "k", value: "v", description: "d",
+                                scope: "bogus", roots: [], sessionID: sidA)
+            XCTFail("expected invalidConfig")
+        } catch VaultError.invalidConfig {
+            // expected
+        }
+    }
+
+    func testAddRejectsRelativeRoot() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        do {
+            try await vault.add(name: "k", value: "v", description: "d",
+                                scope: "project", roots: ["relative/path"], sessionID: sidA)
+            XCTFail("expected invalidConfig")
+        } catch VaultError.invalidConfig {
+            // expected
+        }
+    }
+
+    func testAddRejectsRootWithDotDot() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        do {
+            try await vault.add(name: "k", value: "v", description: "d",
+                                scope: "project", roots: ["/tmp/../etc"], sessionID: sidA)
+            XCTFail("expected invalidConfig")
+        } catch VaultError.invalidConfig {
+            // expected
+        }
+    }
+
+    func testAddRejectsTooManyRoots() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        let tooMany = (1...17).map { "/tmp/r\($0)" }
+        do {
+            try await vault.add(name: "k", value: "v", description: "d",
+                                scope: "project", roots: tooMany, sessionID: sidA)
+            XCTFail("expected invalidConfig")
+        } catch VaultError.invalidConfig {
+            // expected
+        }
+    }
+
+    func testAddProjectScopeStripsTrailingSlash() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo/"], sessionID: sidA)
+        let secret = try await vault.get(name: "k", sessionID: sidA, peerCwd: "/tmp/foo")
+        XCTAssertEqual(secret.roots, ["/tmp/foo"])
+    }
+
+    func testGetProjectScopedSecretInRootSucceeds() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo"], sessionID: sidA)
+        let secret = try await vault.get(name: "k", sessionID: sidA, peerCwd: "/tmp/foo")
+        XCTAssertEqual(secret.value, "v")
+    }
+
+    func testGetProjectScopedSecretInSubdirSucceeds() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo"], sessionID: sidA)
+        let secret = try await vault.get(name: "k", sessionID: sidA, peerCwd: "/tmp/foo/sub/deeper")
+        XCTAssertEqual(secret.value, "v")
+    }
+
+    func testGetProjectScopedSecretFromSiblingFails() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo"], sessionID: sidA)
+        do {
+            _ = try await vault.get(name: "k", sessionID: sidA, peerCwd: "/tmp/foobar")
+            XCTFail("expected secretOutOfScope")
+        } catch VaultError.secretOutOfScope(let name, let roots) {
+            XCTAssertEqual(name, "k")
+            XCTAssertEqual(roots, ["/tmp/foo"])
+        }
+    }
+
+    func testGetProjectScopedSecretWithNilCwdFails() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo"], sessionID: sidA)
+        do {
+            _ = try await vault.get(name: "k", sessionID: sidA, peerCwd: nil)
+            XCTFail("expected secretOutOfScope when cwd is unknown")
+        } catch VaultError.secretOutOfScope {
+            // expected
+        }
+    }
+
+    func testGlobalSecretIgnoresPeerCwd() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d", sessionID: sidA)
+        // peerCwd is irrelevant — global secrets are reachable from anywhere.
+        let secret = try await vault.get(name: "k", sessionID: sidA, peerCwd: "/somewhere")
+        XCTAssertEqual(secret.value, "v")
+    }
+
+    func testListFiltersOutOfScopeProjectSecrets() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "global-key", value: "v", description: "d", sessionID: sidA)
+        try await vault.add(name: "proj-a", value: "va", description: "d",
+                            scope: "project", roots: ["/tmp/A"], sessionID: sidA)
+        try await vault.add(name: "proj-b", value: "vb", description: "d",
+                            scope: "project", roots: ["/tmp/B"], sessionID: sidA)
+
+        let inA = try await vault.list(sessionID: sidA, peerCwd: "/tmp/A")
+        let names = inA.map { $0.name }.sorted()
+        XCTAssertEqual(names, ["global-key", "proj-a"])
+    }
+
+    func testListIncludeAllReturnsEverything() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "global-key", value: "v", description: "d", sessionID: sidA)
+        try await vault.add(name: "proj-a", value: "va", description: "d",
+                            scope: "project", roots: ["/tmp/A"], sessionID: sidA)
+        try await vault.add(name: "proj-b", value: "vb", description: "d",
+                            scope: "project", roots: ["/tmp/B"], sessionID: sidA)
+
+        let all = try await vault.list(sessionID: sidA, peerCwd: "/tmp/A", includeAll: true)
+        XCTAssertEqual(all.count, 3)
+    }
+
+    func testListWithNilCwdReturnsOnlyGlobals() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "global-key", value: "v", description: "d", sessionID: sidA)
+        try await vault.add(name: "proj-a", value: "va", description: "d",
+                            scope: "project", roots: ["/tmp/A"], sessionID: sidA)
+
+        let result = try await vault.list(sessionID: sidA, peerCwd: nil)
+        XCTAssertEqual(result.map { $0.name }, ["global-key"])
+    }
+
+    func testGetOutOfScopeSecretLogsOutOfScope() async throws {
+        try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
+        try await vault.add(name: "k", value: "v", description: "d",
+                            scope: "project", roots: ["/tmp/foo"], sessionID: sidA)
+        accessLog.entries.removeAll()
+        _ = try? await vault.get(name: "k", sessionID: sidA, peerCwd: "/tmp/elsewhere",
+                                 clientId: "test")
+        let last = accessLog.entries.last
+        XCTAssertEqual(last?.method, "vault.get")
+        XCTAssertEqual(last?.secret, "k")
+        XCTAssertEqual(last?.result, "out_of_scope")
+    }
+
     func testUnlockRequiresAuthForExpiredSameSession() async throws {
         try await vault.initialize(recoveryPassphrase: nil, sessionID: sidA)
         _ = try await vault.setConfig(ttlSeconds: 1, sessionID: sidA)


### PR DESCRIPTION
## Summary
- Adds `scope` ("global" | "project") and `roots: []string` to Secret. Backward-compatible decode; no envelope bump.
- Daemon resolves peer cwd via `proc_pidinfo(PROC_PIDVNODEPATHINFO)` (`PeerCwd.resolve`) — the CLI never claims its own cwd.
- `tsm add --here` / `tsm add --project <path>` (repeatable) for project binding.
- `tsm list` defaults to in-scope filter; `--all` reveals everything.
- `tsm get` returns `secret_out_of_scope` (RPC code -32010) when the calling cwd is outside any bound root, with a CLI hint.
- Skill update + design doc (design doc is local-only per repo convention — `docs/plans/` is gitignored).

**Deferred to follow-ups:** `tsm run` auto-inject, `tsm edit --add-root/--remove-root`, recent-projects cache, `tsm project` noun.

Closes #7 (MVP — see PR body for deferred items)

## Test plan
- [ ] `cd tsmd && swift test` passes (incl. PeerCwdTests, scope validation, cwd resolution)
- [ ] `go test ./...` passes (incl. cmd/add_test.go --here, cmd/list_test.go --all, cmd/get_test.go out-of-scope hint)
- [ ] Manual: `tsm add --here --name foo --no-input` from `/tmp/proj` then `cd /tmp/other && tsm get foo` returns the hint