### PR TITLE
feat: gate confirm-mode tsm run on biometric presentability, not caller TTY

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	"golang.org/x/term"
 )
 
 // runnerFunc replaces the current process with the given target. In
@@ -28,7 +27,6 @@ type runnerFunc func(path string, argv, addedEnv []string) error
 type runOptions struct {
 	Envs     []string // raw --env flag values, in order
 	Argv     []string // target command + args
-	StdinTTY bool     // result of term.IsTerminal(os.Stdin.Fd())
 	Runner   runnerFunc
 	LookPath func(string) (string, error)
 }
@@ -67,7 +65,6 @@ Examples:
 				return runWith(c, runOptions{
 					Envs:     envs,
 					Argv:     args,
-					StdinTTY: term.IsTerminal(int(os.Stdin.Fd())),
 					Runner:   execveRunner,
 					LookPath: exec.LookPath,
 				})
@@ -100,26 +97,37 @@ func runWith(c client.Caller, opts runOptions) error {
 		return handleError(err)
 	}
 
-	// Inspect confirm flags via vault.list before fetching, so we can refuse
-	// non-TTY callers without first triggering a Touch ID prompt that they
-	// could not respond to.
-	if !opts.StdinTTY {
-		var metas []runSecretMeta
-		if err := c.Call("vault.list", nil, &metas); err != nil {
+	// A confirm-gated secret triggers a Touch ID prompt presented by the
+	// daemon. The daemon can present that prompt whenever it lives in the
+	// user's GUI session, regardless of how this CLI's stdin is wired — so we
+	// gate on the daemon's biometric presentability (auth.can_confirm), not on
+	// whether our own stdin is a TTY. This lets background/non-TTY callers
+	// (e.g. an agent's Bash tool) use confirm-gated secrets, while still
+	// refusing cleanly in truly headless contexts with no GUI login session,
+	// rather than triggering a prompt nobody can see.
+	var metas []runSecretMeta
+	if err := c.Call("vault.list", nil, &metas); err != nil {
+		return handleError(err)
+	}
+	needed := map[string]bool{}
+	for _, m := range mappings {
+		needed[m.Secret] = true
+	}
+	var confirmSecrets []string
+	for _, m := range metas {
+		if needed[m.Name] && m.Confirm {
+			confirmSecrets = append(confirmSecrets, m.Name)
+		}
+	}
+	if len(confirmSecrets) > 0 {
+		var resp struct {
+			CanConfirm bool `json:"can_confirm"`
+		}
+		if err := c.Call("auth.can_confirm", nil, &resp); err != nil {
 			return handleError(err)
 		}
-		needed := map[string]bool{}
-		for _, m := range mappings {
-			needed[m.Secret] = true
-		}
-		var blocking []string
-		for _, m := range metas {
-			if needed[m.Name] && m.Confirm {
-				blocking = append(blocking, m.Name)
-			}
-		}
-		if len(blocking) > 0 {
-			return fmt.Errorf("refusing to run: secret(s) require confirm-mode authentication but stdin is not a TTY: %s\nChange the secret's confirm setting via 'tsm edit' if non-interactive use is intended", strings.Join(blocking, ", "))
+		if !resp.CanConfirm {
+			return fmt.Errorf("refusing to run: secret(s) require Touch ID confirmation but no biometric prompt can be presented here (no GUI login session): %s\nRun from a session where Touch ID is available, or change the secret's confirm setting via 'tsm edit'", strings.Join(confirmSecrets, ", "))
 		}
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -29,10 +29,9 @@ func TestRun_BadEnvFlag(t *testing.T) {
 	mock := &mockCaller{}
 	var rec recordedExec
 	err := runWith(mock, runOptions{
-		Envs:     []string{"NO_EQUALS"},
-		Argv:     []string{"echo"},
-		StdinTTY: true,
-		Runner:   newFakeRunner(&rec),
+		Envs:   []string{"NO_EQUALS"},
+		Argv:   []string{"echo"},
+		Runner: newFakeRunner(&rec),
 	})
 	if err == nil {
 		t.Fatal("expected parse error")
@@ -49,10 +48,9 @@ func TestRun_NoCommand(t *testing.T) {
 	mock := &mockCaller{}
 	var rec recordedExec
 	err := runWith(mock, runOptions{
-		Envs:     []string{"FOO=bar"},
-		Argv:     nil,
-		StdinTTY: true,
-		Runner:   newFakeRunner(&rec),
+		Envs:   []string{"FOO=bar"},
+		Argv:   nil,
+		Runner: newFakeRunner(&rec),
 	})
 	if err == nil {
 		t.Fatal("expected error when no command provided")
@@ -82,7 +80,6 @@ func TestRun_Success(t *testing.T) {
 	err := runWith(mock, runOptions{
 		Envs:     []string{"GITHUB_TOKEN=gh-pat"},
 		Argv:     []string{"echo", "hi"},
-		StdinTTY: true,
 		Runner:   newFakeRunner(&rec),
 		LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
 	})
@@ -118,7 +115,6 @@ func TestRun_SecretNotFound(t *testing.T) {
 	err := runWith(mock, runOptions{
 		Envs:     []string{"GITHUB_TOKEN=missing"},
 		Argv:     []string{"echo"},
-		StdinTTY: true,
 		Runner:   newFakeRunner(&rec),
 		LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
 	})
@@ -148,7 +144,6 @@ func TestRun_TargetNotFound(t *testing.T) {
 	err := runWith(mock, runOptions{
 		Envs:     []string{"FOO=x"},
 		Argv:     []string{"nonexistent-binary-xyz"},
-		StdinTTY: true,
 		Runner:   newFakeRunner(&rec),
 		LookPath: func(name string) (string, error) { return "", errors.New("not found in PATH") },
 	})
@@ -160,7 +155,10 @@ func TestRun_TargetNotFound(t *testing.T) {
 	}
 }
 
-func TestRun_ConfirmAndNonTTY_Refused(t *testing.T) {
+// When a confirm-gated secret is requested but the daemon reports it cannot
+// present a Touch ID prompt (no GUI login session), run refuses cleanly —
+// regardless of the caller's TTY.
+func TestRun_ConfirmAndBiometricsUnavailable_Refused(t *testing.T) {
 	mock := &mockCaller{
 		onCall: func(method string, params map[string]any) (any, error) {
 			switch method {
@@ -168,6 +166,8 @@ func TestRun_ConfirmAndNonTTY_Refused(t *testing.T) {
 				return nil, nil
 			case "vault.list":
 				return []map[string]any{{"name": "billing-key", "confirm": true}}, nil
+			case "auth.can_confirm":
+				return map[string]any{"can_confirm": false}, nil
 			}
 			return nil, errors.New("unexpected " + method)
 		},
@@ -176,7 +176,6 @@ func TestRun_ConfirmAndNonTTY_Refused(t *testing.T) {
 	err := runWith(mock, runOptions{
 		Envs:     []string{"BILLING=billing-key"},
 		Argv:     []string{"echo"},
-		StdinTTY: false, // not a TTY
 		Runner:   newFakeRunner(&rec),
 		LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
 	})
@@ -186,11 +185,45 @@ func TestRun_ConfirmAndNonTTY_Refused(t *testing.T) {
 	if !strings.Contains(err.Error(), "billing-key") {
 		t.Fatalf("error should name the offending secret, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") {
-		t.Fatalf("error should mention TTY, got: %v", err)
-	}
 	if rec.Path != "" {
 		t.Fatal("runner must not be invoked")
+	}
+}
+
+// A confirm-gated secret proceeds when the daemon reports biometrics CAN be
+// presented — even from a non-TTY caller. The daemon owns the Touch ID prompt;
+// the caller's stdin is irrelevant.
+func TestRun_ConfirmAndBiometricsAvailable_Proceeds(t *testing.T) {
+	mock := &mockCaller{
+		onCall: func(method string, params map[string]any) (any, error) {
+			switch method {
+			case "vault.unlock":
+				return nil, nil
+			case "vault.list":
+				return []map[string]any{{"name": "billing-key", "confirm": true}}, nil
+			case "auth.can_confirm":
+				return map[string]any{"can_confirm": true}, nil
+			case "vault.get":
+				return map[string]string{"name": "billing-key", "value": "sk_live_xyz"}, nil
+			}
+			return nil, errors.New("unexpected " + method)
+		},
+	}
+	var rec recordedExec
+	err := runWith(mock, runOptions{
+		Envs:     []string{"BILLING=billing-key"},
+		Argv:     []string{"echo"},
+		Runner:   newFakeRunner(&rec),
+		LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Path != "/bin/echo" {
+		t.Fatalf("runner should have been invoked, got path %q", rec.Path)
+	}
+	if len(rec.Env) != 1 || rec.Env[0] != "BILLING=sk_live_xyz" {
+		t.Fatalf("env: %v", rec.Env)
 	}
 }
 
@@ -212,7 +245,6 @@ func TestRun_DedupesVaultGets(t *testing.T) {
 	err := runWith(mock, runOptions{
 		Envs:     []string{"GITHUB_TOKEN=gh-pat", "GH_TOKEN=gh-pat"},
 		Argv:     []string{"echo"},
-		StdinTTY: true,
 		Runner:   newFakeRunner(&rec),
 		LookPath: func(name string) (string, error) { return "/bin/" + name, nil },
 	})

--- a/plugin/skills/credential-usage/SKILL.md
+++ b/plugin/skills/credential-usage/SKILL.md
@@ -81,11 +81,24 @@ tsm get gh-pat   --format "env GITHUB_TOKEN" > /dev/shm/envfile   # docker --env
 
 ## 3. Confirm-gated secrets
 
-Some secrets are flagged `"confirm": true` in `tsm list`. Each access triggers a Touch ID prompt, even if the vault is already unlocked. Before invoking such a secret, tell the user to expect the prompt:
+Some secrets are flagged `"confirm": true` in `tsm list --json`. **Check this flag during discovery (§1)** so you know a Touch ID prompt is coming. Each access to a confirm-gated secret triggers a fresh Touch ID prompt, even when the vault is already unlocked.
 
-> "I'm about to fetch `aws-prod`, which is confirm-gated — please approve the Touch ID prompt."
+**You can use confirm-gated secrets directly — your shell's lack of a TTY does not matter.** The prompt is a system Touch ID dialog presented by the tsm *daemon*, which lives in the user's GUI login session; it appears on the user's screen and they approve it with their finger, no matter how your stdin is wired. So `tsm run --env … -- …` works the same from a background/non-TTY shell as from a terminal. **Before you trigger it, warn the user the prompt is coming** — otherwise a Touch ID dialog pops up unexplained:
 
-If a confirm-gated secret is needed and stdin is not a TTY (e.g., the agent is running headless), `tsm run` will refuse with a clear error. That is intended; the user must change the secret's `confirm` setting via `tsm edit` if non-interactive use is needed.
+> "I'm about to start the server with `anthropic-api-key`, which is confirm-gated — you'll get a Touch ID prompt to approve. For a long-running process it's a one-time cost at startup."
+> ```bash
+> tsm run --env ANTHROPIC_API_KEY=anthropic-api-key -- node server.js
+> ```
+
+For long-lived processes (dev servers, daemons, watchers) the prompt fires once at launch and the child keeps the value in its env for its whole lifetime.
+
+`tsm run` only refuses a confirm-gated secret when the daemon genuinely **cannot** present biometrics — a truly headless context with no GUI login session (CI, cron, ssh without a console session). It checks this up front via the daemon rather than guessing from your TTY:
+
+```
+refusing to run: secret(s) require Touch ID confirmation but no biometric prompt can be presented here (no GUI login session): <name>
+```
+
+If you hit that, you really are somewhere Touch ID can't run. Hand the user a command to run where biometrics are available, or — if they want non-interactive use — **suggest** they drop confirm mode with `tsm edit <name>`. Never run `tsm edit` yourself (see §4); dropping a Touch ID gate is the user's call.
 
 ## 4. Never
 

--- a/tsmd/Sources/tsmd/Auth.swift
+++ b/tsmd/Sources/tsmd/Auth.swift
@@ -2,6 +2,14 @@ import Foundation
 import LocalAuthentication
 
 struct TouchIDAuth: AuthProvider, Sendable {
+    /// True when biometrics can be evaluated right now (enrolled, not locked
+    /// out, GUI session present). Presents no UI. Returns false in headless
+    /// contexts with no console session, so callers can refuse cleanly instead
+    /// of triggering a prompt nobody can see.
+    func canAuthenticate() -> Bool {
+        LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    }
+
     func authenticate(reason: String) async throws {
         let context = LAContext()
         var error: NSError?

--- a/tsmd/Sources/tsmd/JSONRPCHandler.swift
+++ b/tsmd/Sources/tsmd/JSONRPCHandler.swift
@@ -135,6 +135,9 @@ actor JSONRPCHandler {
             try await vault.reset(clientId: clientId)
             return .object(["ok": .bool(true)])
 
+        case "auth.can_confirm":
+            return .object(["can_confirm": .bool(await vault.canConfirm())])
+
         case "daemon.capabilities":
             let caps = await vault.capabilities()
             return encodeToJSONValue(caps)

--- a/tsmd/Sources/tsmd/Vault.swift
+++ b/tsmd/Sources/tsmd/Vault.swift
@@ -24,6 +24,13 @@ protocol KeychainProvider: Sendable {
 
 protocol AuthProvider: Sendable {
     func authenticate(reason: String) async throws
+    /// Whether a biometric prompt can be presented right now: biometrics are
+    /// enrolled, not locked out, and a GUI login session exists to host the
+    /// dialog. Does NOT present any UI. This is independent of the connecting
+    /// CLI's TTY — the daemon owns the prompt and can present one whenever it
+    /// lives in the user's GUI session, regardless of how the caller's stdin
+    /// is wired.
+    func canAuthenticate() -> Bool
 }
 
 protocol VaultStoreProvider: Sendable {
@@ -86,6 +93,12 @@ actor Vault {
     }
 
     var isLocked: Bool { data == nil }
+
+    /// Whether the daemon can currently present a Touch ID prompt. Lets a
+    /// caller decide, before requesting a confirm-gated secret, whether the
+    /// confirmation can actually happen here — rather than gating on the
+    /// caller's TTY, which has nothing to do with biometric presentability.
+    func canConfirm() -> Bool { auth.canAuthenticate() }
 
     // MARK: - Init
 

--- a/tsmd/Tests/tsmdTests/JSONRPCHandlerTests.swift
+++ b/tsmd/Tests/tsmdTests/JSONRPCHandlerTests.swift
@@ -63,6 +63,25 @@ final class JSONRPCHandlerTests: XCTestCase {
         XCTAssertEqual(obj["locked"], .bool(false))
     }
 
+    // MARK: - auth.can_confirm
+
+    func testAuthCanConfirmReportsBiometricAvailability() async {
+        auth.canAuthenticateResult = true
+        let yes = await handler.handle(makeRequest(method: "auth.can_confirm"), sessionID: sid)
+        guard case .object(let obj) = yes.result else {
+            XCTFail("Expected object result"); return
+        }
+        XCTAssertEqual(obj["can_confirm"], .bool(true))
+
+        auth.canAuthenticateResult = false
+        let no = await handler.handle(makeRequest(method: "auth.can_confirm"), sessionID: sid)
+        guard case .object(let obj2) = no.result else {
+            XCTFail("Expected object result"); return
+        }
+        XCTAssertEqual(obj2["can_confirm"], .bool(false),
+            "auth.can_confirm must reflect the daemon's biometric presentability, not the caller's TTY")
+    }
+
     // MARK: - CRUD
 
     func testVaultAddAndGet() async {

--- a/tsmd/Tests/tsmdTests/Mocks.swift
+++ b/tsmd/Tests/tsmdTests/Mocks.swift
@@ -61,11 +61,14 @@ final class MockKeychain: KeychainProvider, @unchecked Sendable {
 final class MockAuth: AuthProvider, @unchecked Sendable {
     var shouldFail = false
     var authenticateCalled = false
+    var canAuthenticateResult = true
 
     func authenticate(reason: String) async throws {
         authenticateCalled = true
         if shouldFail { throw VaultError.authFailed }
     }
+
+    func canAuthenticate() -> Bool { canAuthenticateResult }
 }
 
 final class MockVaultStore: VaultStoreProvider, @unchecked Sendable {


### PR DESCRIPTION
## What & why

`tsm run` previously refused **any** confirm-gated secret whenever stdin was not a TTY, using caller-TTY as a proxy for "a human is present to approve." That proxy misfires for agent harnesses like Claude Code's Bash tool: their background shells have no TTY but run in a live GUI login session where Touch ID works fine. The Touch ID prompt is a system dialog presented by the **daemon** (which lives in the user's GUI session) — it appears on the user's screen regardless of how the *caller's* stdin is wired. So the old check blocked a perfectly workable path (verified: `canEvaluatePolicy` returns `true`, and a real prompt appears, from a non-TTY context).

This replaces the TTY heuristic with a capability check against the daemon.

## Changes

**Daemon (`0bc528d`)**
- `AuthProvider.canAuthenticate()` — `canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics)`, presents no UI.
- New `auth.can_confirm` JSON-RPC method via `Vault.canConfirm()` → `{"can_confirm": bool}`.

**CLI + skill (`ee6b5d7`)**
- `tsm run` drops the `term.IsTerminal(stdin)` gate. When requested secrets are confirm-gated, it asks `auth.can_confirm`: proceed (daemon prompts) when biometrics can be presented; refuse cleanly only in truly headless contexts (no GUI session — CI, cron, ssh without a console).
- `credential-usage/SKILL.md` §3 rewritten: confirm-gated secrets now work from non-TTY callers; the agent should warn the user a Touch ID prompt is coming rather than hand off to a separate terminal.

## Behavior change to note

A confirm-gated secret in an *attended* GUI session will now also prompt for genuinely unattended automation (it blocks on the dialog until the system timeout, instead of failing fast as the old TTY check did). That's the intended semantics of confirm mode — require a human touch per access — but it is a change from the prior fail-fast.

## Testing

- Swift: 124 tests pass, incl. new `testAuthCanConfirmReportsBiometricAvailability`.
- Go: all `cmd` tests pass; `tsm run` confirm tests rewritten to drive `auth.can_confirm` (biometrics available → proceeds; unavailable → refuses).
- Live, from a non-TTY shell against installed binaries:
  - `auth.can_confirm` over the wire → `{"can_confirm":true}`.
  - non-confirm `tsm run` → injected via cached unlock, no prompt.
  - confirm `tsm run` → Touch ID prompt appeared and was approved, secret injected. (Old code: hard `stdin is not a TTY` refusal.)