### PR TITLE
fix: detach spawned tsmd stdio so it can't hang an agent harness

### DIFF
--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -1,11 +1,11 @@
 package daemon
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"tsm/internal/client"
@@ -44,43 +44,58 @@ func spawn(sockPath string) (string, error) {
 	os.Remove(sockPath)
 
 	cmd := exec.Command(tsmdBin, "--socket", sockPath)
-	cmd.Stderr = os.Stderr
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", fmt.Errorf("stdout pipe: %w", err)
+	// The daemon outlives this short-lived CLI. If it inherited our stdout/
+	// stderr, those fds would stay open for the daemon's whole life — and an
+	// agent harness (e.g. Claude Code's Bash tool) that waits for its command's
+	// stdio pipes to reach EOF would hang forever on the first tsm call that
+	// has to spawn the daemon. Redirect the daemon's output to its own log file
+	// (or /dev/null), and never hand it our inherited fds. A nil Stdout/Stderr
+	// makes os/exec connect the child to /dev/null, so the nil fallback is safe.
+	if logw := daemonLogWriter(); logw != nil {
+		cmd.Stdout = logw
+		cmd.Stderr = logw
+		defer logw.Close()
 	}
+
+	// Put the daemon in its own session so signals aimed at the CLI's process
+	// group (Ctrl-C, the harness killing the foreground command) don't take it
+	// down with them.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("start tsmd: %w", err)
 	}
 
-	scanner := bufio.NewScanner(stdout)
-	done := make(chan string, 1)
-	go func() {
-		if scanner.Scan() {
-			done <- scanner.Text()
-		}
-	}()
-
-	select {
-	case line := <-done:
-		if line != "" {
-			sockPath = line
-		}
-	case <-time.After(spawnTimeout):
-		cmd.Process.Kill()
-		return "", fmt.Errorf("tsmd did not print socket path within %s", spawnTimeout)
-	}
-
+	// Readiness is the socket becoming live. We pass --socket explicitly, so
+	// there's no need to read a path back from the daemon's stdout.
 	if err := waitForSocket(sockPath, spawnTimeout); err != nil {
 		cmd.Process.Kill()
-		return "", fmt.Errorf("tsmd started but socket not ready: %w", err)
+		return "", fmt.Errorf("tsmd started but socket not ready within %s (see %s): %w", spawnTimeout, paths.DaemonLog(), err)
 	}
 
-	go cmd.Wait()
+	// Fully disown: we never wait on the daemon, and it has its own session.
+	_ = cmd.Process.Release()
 
 	return sockPath, nil
+}
+
+// daemonLogWriter opens the daemon log file for appending, falling back to
+// /dev/null. It never returns the caller's stdio: the spawned daemon must not
+// inherit fds that an agent harness is waiting on. Returns nil only if even
+// /dev/null can't be opened, in which case the caller leaves Stdout/Stderr nil
+// (os/exec then connects the child to /dev/null anyway).
+func daemonLogWriter() *os.File {
+	logPath := paths.DaemonLog()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err == nil {
+		if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+			return f
+		}
+	}
+	if f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0); err == nil {
+		return f
+	}
+	return nil
 }
 
 func waitForSocket(path string, timeout time.Duration) error {

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -3,12 +3,120 @@ package daemon
 import (
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"tsm/internal/client"
 )
+
+// fakeTsmdScript stands in for the real daemon: it binds the requested unix
+// socket, writes a marker to stderr, records its pid next to the socket, and
+// stays alive — enough to exercise spawn()'s stdio redirection and detachment
+// without needing the Swift binary.
+const fakeTsmdScript = `#!/usr/bin/env python3
+import os, socket, sys, threading, time
+sock = None
+a = sys.argv[1:]
+for i, v in enumerate(a):
+    if v == "--socket":
+        sock = a[i + 1]
+sys.stderr.write("FAKE_TSMD_STDERR_MARKER\n")
+sys.stderr.flush()
+with open(sock + ".pid", "w") as f:
+    f.write(str(os.getpid()))
+try:
+    os.unlink(sock)
+except FileNotFoundError:
+    pass
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(sock)
+s.listen(16)
+def serve():
+    while True:
+        try:
+            conn, _ = s.accept()
+            conn.close()
+        except OSError:
+            break
+threading.Thread(target=serve, daemon=True).start()
+time.sleep(30)
+`
+
+// TestSpawn_RedirectsDaemonStdioToLogAndDetaches verifies the two properties
+// that keep an agent harness from hanging on the first tsm call: the spawned
+// daemon's output goes to its log file (not the caller's inherited stdio), and
+// the daemon runs in its own session.
+func TestSpawn_RedirectsDaemonStdioToLogAndDetaches(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+	dir := shortTempDir(t)
+	sock := filepath.Join(dir, "vault.sock")
+
+	fake := filepath.Join(dir, "tsmd")
+	if err := os.WriteFile(fake, []byte(fakeTsmdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TSM_AUTH_SOCK", sock)
+	t.Setenv("TSM_TSMD_BIN", fake)
+	t.Setenv("XDG_DATA_HOME", dir) // paths.DaemonLog() => dir/tsm/tsmd.log
+
+	t.Cleanup(func() {
+		if b, err := os.ReadFile(sock + ".pid"); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil {
+				syscall.Kill(pid, syscall.SIGKILL)
+			}
+		}
+	})
+
+	path, err := EnsureRunning()
+	if err != nil {
+		t.Fatalf("EnsureRunning: %v", err)
+	}
+	if !client.IsSocketLive(path) {
+		t.Fatal("daemon socket not live after spawn")
+	}
+
+	// The daemon's stderr must land in the log file, not be inherited from the
+	// caller — otherwise an agent harness waiting on its command's stdio pipes
+	// hangs forever on the first spawn.
+	logPath := filepath.Join(dir, "tsm", "tsmd.log")
+	var logged bool
+	for i := 0; i < 40; i++ {
+		if b, _ := os.ReadFile(logPath); strings.Contains(string(b), "FAKE_TSMD_STDERR_MARKER") {
+			logged = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !logged {
+		t.Fatalf("daemon stderr marker not found in %s — stdio not redirected to log", logPath)
+	}
+
+	// The daemon must be detached into its own session (Setsid): a session
+	// leader's process-group id equals its own pid.
+	b, err := os.ReadFile(sock + ".pid")
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		t.Fatalf("parse pid: %v", err)
+	}
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("getpgid(%d): %v", pid, err)
+	}
+	if pgid != pid {
+		t.Fatalf("daemon not session-detached: pgid=%d pid=%d (want equal)", pgid, pid)
+	}
+}
 
 // shortTempDir returns a short-pathed temp directory, since macOS Unix sockets
 // have a 104-char path limit and the default t.TempDir() under /var/folders/...

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -32,6 +32,13 @@ func ConfigFile() string {
 	return filepath.Join(configDir(), "config.json")
 }
 
+// DaemonLog returns the path to the tsmd daemon's stdout/stderr log file.
+// The CLI redirects the spawned daemon's output here so it never inherits the
+// caller's stdio (which would hang an agent harness waiting on those fds).
+func DaemonLog() string {
+	return filepath.Join(dataDir(), "tsmd.log")
+}
+
 // TsmdBin returns the expected path to the tsmd binary.
 // Looks in the same directory as the running tsm binary first,
 // then falls back to ~/.local/bin/tsmd.

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -66,3 +66,22 @@ func TestAccessLog_Default(t *testing.T) {
 		t.Fatalf("expected %s, got %s", expected, p)
 	}
 }
+
+func TestDaemonLog_Default(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "")
+	p := DaemonLog()
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".local", "share", "tsm", "tsmd.log")
+	if p != expected {
+		t.Fatalf("expected %s, got %s", expected, p)
+	}
+}
+
+func TestDaemonLog_XDG(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/tmp/xdg-data")
+	p := DaemonLog()
+	expected := filepath.Join("/tmp/xdg-data", "tsm", "tsmd.log")
+	if p != expected {
+		t.Fatalf("expected %s, got %s", expected, p)
+	}
+}


### PR DESCRIPTION
## The bug

The CLI auto-spawns `tsmd` and set `cmd.Stderr = os.Stderr`. Because `tsmd` is **long-lived**, it kept a copy of the caller's stderr fd open for its entire life. Under an agent harness like Claude Code's Bash tool — which considers a command finished only when its stdout/stderr pipes reach EOF — that fd never closes, so the **first** `tsm` call that has to spawn the daemon hangs the harness forever, even though the `tsm` process itself already exited.

In a normal terminal the same code is harmless (a tty isn't waiting for EOF), which is why it only bites under agents. This is a likely contributor to first-call credential-access friction for agents.

## The fix (`spawn()` in `internal/daemon/lifecycle.go`)

- Redirect the daemon's stdout+stderr to a log file — new `paths.DaemonLog()` → `<dataDir>/tsmd.log` — falling back to `/dev/null`. Never the caller's stdio.
- Start it in its own session (`Setsid`) so signals to the CLI's process group don't take the daemon down, and `Process.Release()` to fully disown it.
- Drop the stdout socket-path readback. `--socket` is passed explicitly, so readiness comes from `waitForSocket()` polling the socket for liveness. (Bonus: removes a 10s-timeout failure path when the daemon is slow to print.)

## Testing

- New deterministic `TestSpawn_RedirectsDaemonStdioToLogAndDetaches`: a fake python `tsmd` binds the socket and writes a marker to stderr; the test asserts the marker lands in the **log file** (proving stderr is redirected, not inherited) and that the daemon runs in its **own session** (`getpgid(pid) == pid`). Red before the fix (stderr leaked to the test's own stderr; 10s stdout-readback timeout), green after.
- Added `paths.DaemonLog()` tests (default + `XDG_DATA_HOME`).
- Full Go suite, `gofmt`, and `go vet` clean.
- Live: with no daemon running, a cold `tsm status` spawned the daemon and **returned in ~1s** (previously hung), daemon detached and alive, `~/.local/share/tsm/tsmd.log` created.

## Notes

- Independent of #16 (that PR is the confirm/biometric gating; this is process lifecycle). No conflicts expected — disjoint files.
- Startup-failure detection shifts from "missing stdout line" to `waitForSocket` timing out, with the reason captured in `tsmd.log`.